### PR TITLE
Configure GitHub issues with build logs on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
         libgtk2.0-dev python3-tk python3-dev libboost-python-dev libmodbus-dev \
         libusb-1.0-0-dev libudev-dev python3-serial python3-usb python3-numpy
 
+    - name: Authenticate GitHub CLI
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
     - name: Build PoKeysLib
       run: |
         mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -77,10 +77,28 @@ jobs:
       run: |
         echo "Build failed, attaching logs."
         LOG_FILE="build.log"
-        if [ -f $LOG_FILE ]; then
+        if [ -f $LOG_FILE]; then
           gh issue create --title "Build Error: ${{ github.sha }}" --body-file $LOG_FILE --label "build-error" --assignee @your-username
         else
           echo "No build log found."
+```
+
+## Setting up GitHub CLI Authentication
+
+To enable the `gh` command to create issues, you need to authenticate the GitHub CLI with a GitHub token. Follow these steps:
+
+1. Install GitHub CLI by following the instructions [here](https://cli.github.com/manual/installation).
+2. Authenticate the GitHub CLI with your GitHub account by running the following command and following the prompts:
+
+```sh
+gh auth login
+```
+
+3. Generate a GitHub token with the necessary permissions by following the instructions [here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+4. Configure the `gh` command to use the generated token by running the following command:
+
+```sh
+export GH_TOKEN=YOUR_GITHUB_TOKEN
 ```
 
 ## Testing the Setup


### PR DESCRIPTION
Related to #1

Add GitHub CLI authentication and issue creation in GitHub Actions workflow.

* **README.md**
  - Add instructions for setting up GitHub CLI authentication.
  - Add instructions for configuring the `gh` command to create issues.

* **.github/workflows/build.yml**
  - Add a step to authenticate GitHub CLI using a GitHub token.
  - Update the `Create GitHub Issue on Failure` step to use the authenticated `gh` command.

* **.github/workflows/ci.yml**
  - Delete the empty file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/pokeyslib-fork/issues/1?shareId=a8a4abdb-8d6c-42d1-a30d-007e8849803f).