### PR TITLE
Fix submodule path issue in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,9 +37,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Initialize submodules
-      run: git submodule update --init --recursive
-
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,8 +114,16 @@ jobs:
 
     - name: Set up auth
       run: |
+        echo "Setting up auth"
         git config --local --name-only --get-regexp core\.sshCommand
         git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
+        echo "Auth setup complete"
+
+    - name: Log .gitmodules file
+      run: |
+        echo "Logging .gitmodules file"
+        cat .gitmodules
+        echo "Logging complete"
 
     - name: Temporarily override HOME
       run: export HOME=/home/zarfld/actions-runner2/_work/_temp/1b4ae179-fc69-433d-ba3a-3ec87d24903c

--- a/README.md
+++ b/README.md
@@ -52,9 +52,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-    - name: Clone PoKeysLib repository
-      run: |
-        git clone https://bitbucket.org/mbosnak/pokeyslib pokeyslib
+    - name: Initialize submodules
+      run: git submodule update --init --recursive
 
     - name: Commit and push updates
       run: |


### PR DESCRIPTION
Related to #12

Update GitHub Actions workflow to fix submodule initialization issue.

* **README.md**
  - Remove the redundant 'Clone PoKeysLib repository' step.
  - Add the 'Initialize submodules' step in the 'update-pokeyslib' job.

* **.github/workflows/build.yml**
  - Remove the redundant 'Initialize submodules' step from the 'build' job.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/pokeyslib-fork/issues/12?shareId=c2041723-0f3b-42a4-951c-1f109d07cd4a).