### PR TITLE
Add missing asynchronous functions to PoKeysLibCoreAsync.c and PoKeysLibCoreSocketsAsync.c

### DIFF
--- a/PoKeysLibCoreAsync.c
+++ b/PoKeysLibCoreAsync.c
@@ -478,3 +478,761 @@ sPoKeysDevice *PK_ConnectToDeviceWSerial_Async(uint32_t serial, uint32_t timeout
 
     return NULL; // still connecting
 }
+
+int32_t PK_EnumerateUSBDevices()
+{
+    int32_t numDevices = 0;
+    struct hid_device_info *devs, *cur_dev;
+
+    devs = hid_enumerate(0x1DC3, 0x1001);
+    cur_dev = devs;
+
+    while (cur_dev)
+    {
+        if (PKI_CheckInterface(cur_dev))
+        {
+            numDevices++;
+        }
+
+        cur_dev = cur_dev->next;
+    }
+    hid_free_enumeration(devs);
+
+    devs = hid_enumerate(0x1DC3, 0x1002);
+    cur_dev = devs;
+
+    while (cur_dev)
+    {
+        if (cur_dev->interface_number == -1) numDevices++;
+        cur_dev = cur_dev->next;
+    }
+    hid_free_enumeration(devs);
+
+#ifdef POKEYSLIB_USE_LIBUSB
+    numDevices += PK_EnumerateFastUSBDevices();
+#endif
+    return numDevices;
+}
+
+int32_t PK_GetCurrentDeviceConnectionType(sPoKeysDevice* device)
+{
+    return device->connectionType;
+}
+
+void InitializeNewDevice(sPoKeysDevice* device)
+{
+    uint32_t i;    
+    memset(&device->info, 0, sizeof(sPoKeysDevice_Info));
+    memset(&device->DeviceData, 0, sizeof(sPoKeysDevice_Data));
+
+    device->netDeviceData = 0;
+
+    memset(&device->matrixKB, 0, sizeof(sMatrixKeyboard));
+    memset(&device->PWM, 0, sizeof(sPoKeysPWM));
+    memset(&device->LCD, 0, sizeof(sPoKeysLCD));
+    
+
+    device->FastEncodersConfiguration = 0;
+    device->FastEncodersOptions = 0;
+    device->UltraFastEncoderConfiguration = 0;
+    device->UltraFastEncoderOptions = 0;
+
+    device->UltraFastEncoderFilter = 0;
+
+    memset(device->request, 0, 64);
+    memset(device->response, 0, 64);
+
+    device->sendRetries = 3;
+    device->readRetries = 10;
+    device->socketTimeout = 100;
+
+    PK_DeviceDataGet(device);
+
+    device->Pins = (sPoKeysPinData*)malloc(sizeof(sPoKeysPinData) * device->info.iPinCount);
+    memset(device->Pins, 0, sizeof(sPoKeysPinData) * device->info.iPinCount);
+
+
+    for (i = 0; i < device->info.iPinCount; i++)
+    {
+        if (PK_IsCounterAvailable(device, i))
+        {
+            device->Pins[i].DigitalCounterAvailable = 1;
+        } else
+        {
+            device->Pins[i].DigitalCounterAvailable = 0;
+        }
+    }
+
+    device->Encoders = (sPoKeysEncoder*)malloc(sizeof(sPoKeysEncoder) * device->info.iEncodersCount);
+    memset(device->Encoders, 0, sizeof(sPoKeysEncoder) * device->info.iEncodersCount);
+
+    if (device->info.iEasySensors)
+    {
+        device->EasySensors = (sPoKeysEasySensor*)malloc(sizeof(sPoKeysEasySensor) * device->info.iEasySensors);
+        memset(device->EasySensors, 0, sizeof(sPoKeysEasySensor) * device->info.iEasySensors);
+    } else
+    {
+        device->EasySensors = NULL;
+    }
+
+    device->PWM.PWMduty = (uint32_t*)malloc(sizeof(uint32_t) * device->info.iPWMCount);
+    memset(device->PWM.PWMduty, 0, sizeof(uint32_t) * device->info.iPWMCount);
+
+    if (device->info.iPWMCount > 0)
+    {
+        device->PWM.PWMenabledChannels = (unsigned char*)malloc(sizeof(unsigned char) * device->info.iPWMCount);
+        memset(device->PWM.PWMenabledChannels, 0, sizeof(unsigned char) * device->info.iPWMCount);
+    }
+    else
+    {
+        device->PWM.PWMenabledChannels = NULL;
+    }
+    device->PWM.PWMpinIDs = (unsigned char*)malloc(sizeof(unsigned char) * device->info.iPWMCount);
+    memset(device->PWM.PWMpinIDs, 0, sizeof(unsigned char) * device->info.iPWMCount);
+
+    PK_FillPWMPinNumbers(device);
+
+    device->PoExtBusData = (unsigned char*)malloc(sizeof(unsigned char) * device->info.iPoExtBus);
+
+    device->MatrixLED = (sPoKeysMatrixLED*)malloc(sizeof(sPoKeysMatrixLED) * device->info.iMatrixLED);
+    memset(device->MatrixLED, 0, sizeof(sPoKeysMatrixLED) * device->info.iMatrixLED);
+
+    memset(&device->PEv2, 0, sizeof(sPoKeysPEv2));
+
+    device-> multiPartBuffer = malloc(512);
+    if (device->multiPartBuffer <= 0) device->multiPartBuffer = 0;
+
+#ifdef USE_ALIGN_TEST
+    device->alignTest1 = 1;
+    device->alignTest2 = 2;
+    device->alignTest3 = 3;
+    device->alignTest4 = 4;
+    device->alignTest5 = 5;
+    device->alignTest6 = 6;
+    device->alignTest7 = 7;
+    device->alignTest8 = 8;
+    device->alignTest9 = 9;
+    device->alignTest10 = 10;
+    device->alignTest11 = 11;
+#endif
+}
+
+void CleanDevice(sPoKeysDevice* device)
+{    
+    free(device->Pins);
+    device->Pins = NULL;
+    free(device->Encoders);
+    device->Encoders = NULL;
+    free(device->PWM.PWMduty);
+    device->PWM.PWMduty = NULL;
+    free(device->PWM.PWMenabledChannels);
+    device->PWM.PWMenabledChannels = NULL;
+    free(device->PWM.PWMpinIDs);
+    device->PWM.PWMpinIDs = NULL;
+    free(device->PoExtBusData);
+    device->PoExtBusData = NULL;
+    free(device->MatrixLED);
+    device->MatrixLED = NULL;
+
+    if (device->multiPartBuffer != NULL)
+    {
+        free(device->multiPartBuffer);
+        device->multiPartBuffer = NULL;
+    }
+
+    if (device->EasySensors != NULL)
+    {
+        free(device->EasySensors);
+        device->EasySensors = NULL;
+    }
+
+    if (device->netDeviceData != NULL)
+    {
+        free(device->netDeviceData);
+        device->netDeviceData = NULL;
+    }
+}
+
+void PK_ReleaseDeviceStructure(sPoKeysDevice* device)
+{
+    CleanDevice(device);
+}
+
+void PK_CloneDeviceStructure(sPoKeysDevice* original, sPoKeysDevice *destination)
+{
+    // Reserve memory...
+    destination->Pins = (sPoKeysPinData*)malloc(sizeof(sPoKeysPinData) * original->info.iPinCount);
+    destination->Encoders = (sPoKeysEncoder*)malloc(sizeof(sPoKeysEncoder) * original->info.iEncodersCount);
+    destination->PWM.PWMduty = (uint32_t*)malloc(sizeof(uint32_t) * original->info.iPWMCount);
+    destination->PWM.PWMenabledChannels = (unsigned char*)malloc(sizeof(unsigned char) * original->info.iPWMCount);
+    if (original->info.iPWMCount == 0) destination->PWM.PWMenabledChannels = NULL;
+    destination->PWM.PWMpinIDs = (unsigned char*)malloc(sizeof(unsigned char) * original->info.iPWMCount);
+    destination->MatrixLED = (sPoKeysMatrixLED*)malloc(sizeof(sPoKeysMatrixLED) * original->info.iMatrixLED);
+
+    if (original->info.iEasySensors)
+    {
+        destination->EasySensors = (sPoKeysEasySensor*)malloc(sizeof(sPoKeysEasySensor) * original->info.iEasySensors);
+    } else
+    {
+        destination->EasySensors = 0;
+    }
+
+    // Network device information structure...
+    if (original->netDeviceData != 0)
+    {
+        destination->netDeviceData = (sPoKeysNetworkDeviceInfo *)malloc(sizeof(sPoKeysNetworkDeviceInfo));
+        memcpy(destination->netDeviceData, original->netDeviceData, sizeof(sPoKeysNetworkDeviceInfo));
+    } else
+    {
+        destination->netDeviceData = 0;
+    }
+    destination->PoExtBusData = (unsigned char*)malloc(sizeof(unsigned char) * original->info.iPoExtBus);
+
+
+    // Copy data
+    destination->devHandle = original->devHandle;
+    destination->devHandle2 = original->devHandle2;
+
+    destination->info = original->info;
+    destination->DeviceData = original->DeviceData;
+
+    memcpy(&destination->Pins[0], &original->Pins[0],
+            original->info.iPinCount * sizeof(sPoKeysPinData));
+    memcpy(&destination->Encoders[0], &original->Encoders[0],
+            original->info.iEncodersCount * sizeof(sPoKeysEncoder));
+
+
+    if (original->info.iEasySensors)
+    {
+        memcpy(&destination->EasySensors[0], &original->EasySensors[0],
+                original->info.iEasySensors * sizeof(sPoKeysEasySensor));
+    }
+
+    destination->matrixKB = original->matrixKB;
+
+    destination->PWM.PWMperiod = original->PWM.PWMperiod;
+    memcpy(destination->PWM.PWMduty, original->PWM.PWMduty,
+           sizeof(uint32_t) * original->info.iPWMCount);
+    memcpy(destination->PWM.PWMenabledChannels, original->PWM.PWMenabledChannels,
+           sizeof(unsigned char) * original->info.iPWMCount);
+    memcpy(destination->PWM.PWMpinIDs, original->PWM.PWMpinIDs,
+           sizeof(unsigned char) * original->info.iPWMCount);
+
+    memcpy(destination->MatrixLED, original->MatrixLED,
+           sizeof(sPoKeysMatrixLED) * original->info.iMatrixLED);
+
+    destination->LCD = original->LCD;
+
+    destination->PoNETmodule = original->PoNETmodule;
+    destination->PoIL = original->PoIL;
+    destination->RTC = original->RTC;
+
+    destination->FastEncodersConfiguration =    original->FastEncodersConfiguration;
+    destination->FastEncodersOptions =          original->FastEncodersOptions;
+    destination->UltraFastEncoderConfiguration =original->UltraFastEncoderConfiguration;
+    destination->UltraFastEncoderOptions =      original->UltraFastEncoderOptions;
+    destination->UltraFastEncoderFilter =       original->UltraFastEncoderFilter;
+
+    memcpy(destination->PoExtBusData, original->PoExtBusData, sizeof(unsigned char) * original->info.iPoExtBus);
+
+    destination->connectionType = original->connectionType;
+    destination->requestID = original->requestID;
+
+}
+
+void * PK_FastUSBConnectToDevice(uint32_t deviceIndex);
+
+sPoKeysDevice* PK_ConnectToDevice(uint32_t deviceIndex)
+{
+    int32_t numDevices = 0;
+    struct hid_device_info *devs, *cur_dev;
+    sPoKeysDevice* tmpDevice;
+    void * devData;
+
+    devs = hid_enumerate(0x1DC3, 0x1001);
+    cur_dev = devs;
+
+    while (cur_dev)
+    {
+        if (cur_dev->interface_number == 1)
+        {
+            if (numDevices == deviceIndex)
+            {
+                tmpDevice = (sPoKeysDevice*)malloc(sizeof(sPoKeysDevice));
+
+                tmpDevice->devHandle = (void*)hid_open_path(cur_dev->path);
+                tmpDevice->devHandle2 = NULL;
+
+                tmpDevice->connectionType = PK_DeviceType_USBDevice;
+
+
+                if (tmpDevice->devHandle != NULL)
+                {
+                    InitializeNewDevice(tmpDevice);
+                } else
+                {
+                    free(tmpDevice);
+                    tmpDevice = NULL;
+                }
+                hid_free_enumeration(devs);
+                return tmpDevice;
+            }
+            numDevices++;
+        }
+        cur_dev = cur_dev->next;
+    }
+    hid_free_enumeration(devs);
+
+    devs = hid_enumerate(0x1DC3, 0x1002);
+    cur_dev = devs;
+
+    while (cur_dev)
+    {
+        if (cur_dev->interface_number == -1)
+        {
+            if (numDevices == deviceIndex)
+            {
+                tmpDevice = (sPoKeysDevice*)malloc(sizeof(sPoKeysDevice));
+
+                tmpDevice->devHandle = (void*)hid_open_path(cur_dev->path);
+                tmpDevice->devHandle2 = NULL;
+
+                tmpDevice->connectionType = PK_DeviceType_USBDevice;
+
+                if (tmpDevice->devHandle != NULL)
+                {
+                    InitializeNewDevice(tmpDevice);
+                } else
+                {
+                    free(tmpDevice);
+                    tmpDevice = NULL;
+                }
+                hid_free_enumeration(devs);
+                return tmpDevice;
+            }
+            numDevices++;
+        }
+        cur_dev = cur_dev->next;
+    }
+    hid_free_enumeration(devs);
+
+#ifdef POKEYSLIB_USE_LIBUSB
+    devData = PK_FastUSBConnectToDevice(deviceIndex - numDevices);
+
+    if (devData != NULL)
+    {
+        tmpDevice = (sPoKeysDevice*)malloc(sizeof(sPoKeysDevice));
+
+        tmpDevice->devHandle = NULL;
+        tmpDevice->devHandle2 = devData;
+
+        tmpDevice->connectionType = PK_DeviceType_FastUSBDevice;
+        InitializeNewDevice(tmpDevice);
+        return tmpDevice;
+    }
+#endif
+    return NULL;
+}
+
+sPoKeysDevice* PK_ConnectToPoKeysDevice_USB(uint32_t serialNumber, uint32_t flags)
+{
+    int32_t numDevices = 0;
+    struct hid_device_info *devs, *cur_dev;
+    int32_t k;
+    sPoKeysDevice* tmpDevice;
+    uint8_t serialSearch[8];
+
+    int devRange = 0;
+    uint8_t deviceTypeRequested = (flags >> 1) & 0x7F;
+
+#ifdef POKEYSLIB_USE_LIBUSB
+    void * devData = ConnectToFastUSBInterface(serialNumber);
+    if (devData != NULL)
+    {
+        tmpDevice = (sPoKeysDevice*)malloc(sizeof(sPoKeysDevice));
+
+        tmpDevice->devHandle = NULL;
+        tmpDevice->devHandle2 = devData;
+
+        tmpDevice->connectionType = PK_DeviceType_FastUSBDevice;
+        InitializeNewDevice(tmpDevice);    
+        return tmpDevice;
+    }
+#endif
+
+    devs = hid_enumerate(0x1DC3, 0x1001);
+    cur_dev = devs;
+
+    sprintf((char*)serialSearch, "x.%05u", serialNumber % 100000);
+
+    while (cur_dev)
+    {
+        if ((cur_dev->interface_number == 1 && devRange == 0) ||
+            (cur_dev->interface_number == 0 && devRange == 1))
+        {
+            if (cur_dev->serial_number != 0 && cur_dev->serial_number[0] != 'P')
+            {
+                for (k = 1; k < 8 && cur_dev->serial_number[k] != 0; k++)
+                {
+                    if (cur_dev->serial_number[k] != serialSearch[k]) break;
+                }
+
+                if (deviceTypeRequested == 2 && cur_dev->serial_number[0] != '2') k = 0;
+                if (deviceTypeRequested == 3 && cur_dev->serial_number[0] != '3') k = 0;
+                if (deviceTypeRequested == 4 && cur_dev->serial_number[0] != '4') k = 0;
+
+                if (k == 7)
+                {
+                    tmpDevice = (sPoKeysDevice*)malloc(sizeof(sPoKeysDevice));
+
+                    tmpDevice->devHandle = (void*)hid_open_path(cur_dev->path);
+                    tmpDevice->devHandle2 = 0;
+
+                    tmpDevice->connectionType = PK_DeviceType_USBDevice;
+                    if (tmpDevice->devHandle != NULL)
+                    {
+                        InitializeNewDevice(tmpDevice);
+                    }
+                    else
+                    {
+                        free(tmpDevice);
+                        tmpDevice = NULL;
+                    }
+                    hid_free_enumeration(devs);
+                    return tmpDevice;
+                }
+            }
+            else
+            {
+                tmpDevice = (sPoKeysDevice*)malloc(sizeof(sPoKeysDevice));
+                tmpDevice->devHandle = (void*)hid_open_path(cur_dev->path);
+                tmpDevice->devHandle2 = 0;
+
+                if (tmpDevice->devHandle != NULL)
+                {
+                    InitializeNewDevice(tmpDevice);
+                }
+                else
+                {
+                    free(tmpDevice);
+                    tmpDevice = NULL;
+                    hid_free_enumeration(devs);
+                    return NULL;
+                }
+
+                tmpDevice->connectionType = PK_DeviceType_USBDevice;
+                if (tmpDevice->DeviceData.SerialNumber == serialNumber)
+                {
+                    hid_free_enumeration(devs);
+                    return tmpDevice;
+                }
+                else
+                {
+                    CleanDevice(tmpDevice);
+                    free(tmpDevice);
+                }
+            }
+
+            numDevices++;
+        }
+        cur_dev = cur_dev->next;
+
+        if (cur_dev == NULL)
+        {
+            devRange++;
+            switch (devRange)
+            {
+                case 1:
+                    hid_free_enumeration(devs);
+                    devs = hid_enumerate(0x1DC3, 0x1001);
+                    cur_dev = devs;
+                    break;
+            }
+        }
+    }
+    hid_free_enumeration(devs);
+    return NULL;
+}
+
+sPoKeysDevice* PK_ConnectToPoKeysDevice_Ethernet(uint32_t serialNumber, uint32_t checkForNetworkDevicesAndTimeout, uint32_t flags)
+{
+    int32_t k;
+    sPoKeysDevice* tmpDevice;
+    sPoKeysNetworkDeviceSummary * devices;
+    int32_t iNet;
+
+    if (checkForNetworkDevicesAndTimeout)
+    {
+        devices = (sPoKeysNetworkDeviceSummary*)malloc(sizeof(sPoKeysNetworkDeviceSummary) * 16);
+        iNet = PK_SearchNetworkDevices(devices, checkForNetworkDevicesAndTimeout, serialNumber);
+
+        if (iNet > 16) iNet = 16;
+
+        for (k = 0; k < iNet; k++)
+        {
+            if (devices[k].SerialNumber == serialNumber)
+            {
+                if (flags & 1) devices[k].useUDP = 1;
+                tmpDevice = PK_ConnectToNetworkDevice(&devices[k]);
+                if (tmpDevice == NULL)
+                {
+                    free(tmpDevice);
+                }
+                else
+                {
+                    free(devices);
+                    InitializeNewDevice(tmpDevice);
+                    return tmpDevice;
+                }
+            }
+        }
+        free(devices);
+    }
+
+    return NULL;
+}
+
+sPoKeysDevice* PK_ConnectToPoKeysDevice(uint32_t serialNumber, uint32_t checkForNetworkDevicesAndTimeout, uint32_t flags)
+{
+    sPoKeysDevice* tmpDevice = NULL;
+
+    if ((flags & (1 << 8)) && checkForNetworkDevicesAndTimeout > 0)
+    {
+        tmpDevice = PK_ConnectToPoKeysDevice_Ethernet(serialNumber, checkForNetworkDevicesAndTimeout, flags);
+    }
+
+    if (tmpDevice == NULL)
+    {
+        tmpDevice = PK_ConnectToPoKeysDevice_USB(serialNumber, flags);
+    }
+    if (tmpDevice == NULL && ((flags & (1 << 8)) == 0) && checkForNetworkDevicesAndTimeout > 0)
+    {
+        tmpDevice = PK_ConnectToPoKeysDevice_Ethernet(serialNumber, checkForNetworkDevicesAndTimeout, flags);
+    }
+    return tmpDevice;
+}
+
+sPoKeysDevice* PK_ConnectToDeviceWSerial(uint32_t serialNumber, uint32_t checkForNetworkDevicesAndTimeout)
+{
+    return PK_ConnectToPoKeysDevice(serialNumber, checkForNetworkDevicesAndTimeout, 0);
+}
+
+sPoKeysDevice* PK_ConnectToDeviceWSerial_UDP(uint32_t serialNumber, uint32_t checkForNetworkDevicesAndTimeout)
+{
+    return PK_ConnectToPoKeysDevice(serialNumber, checkForNetworkDevicesAndTimeout, 1);
+}
+
+void PK_DisconnectDevice(sPoKeysDevice* device)
+{
+    if (device != NULL)
+    {
+        if (device->connectionType == PK_DeviceType_NetworkDevice) 
+        {
+            PK_DisconnectNetworkDevice(device);
+        } else
+        {
+#ifdef POKEYSLIB_USE_LIBUSB
+            DisconnectFromFastUSBInterface(device->devHandle2);
+            device->devHandle2 = NULL;
+#endif
+
+            if ((hid_device*)device->devHandle != NULL)
+            {
+                hid_close((hid_device*)device->devHandle);
+            }
+        }
+
+        CleanDevice(device);
+        free(device);
+    }
+}
+
+int32_t CreateRequest(unsigned char * request, unsigned char type, unsigned char param1, unsigned char param2, unsigned char param3, unsigned char param4)
+{
+    if (request == NULL) return PK_ERR_NOT_CONNECTED;
+
+    memset(request, 0, 64);
+
+    request[1] = type;
+    request[2] = param1;
+    request[3] = param2;
+    request[4] = param3;
+    request[5] = param4;
+
+    return PK_OK;
+}
+
+int32_t PK_CustomRequest(sPoKeysDevice* device, unsigned char type, unsigned char param1, unsigned char param2, unsigned char param3, unsigned char param4)
+{
+    device->request[1] = type;
+    device->request[2] = param1;
+    device->request[3] = param2;
+    device->request[4] = param3;
+    device->request[5] = param4;
+
+    return SendRequest(device);
+}
+
+uint8_t getChecksum(uint8_t * data)
+{
+    uint8_t temp = 0;
+    uint32_t i;
+
+    for (i = 0; i < 7; i++)
+    {
+            temp += data[i];
+    }
+    return temp;
+}
+
+int32_t LastRetryCount = 0;
+int32_t LastWaitCount = 0;
+
+int32_t SendRequest_multiPart(sPoKeysDevice* device)
+{
+    if (device == NULL) return PK_ERR_GENERIC;
+    if (device->connectionType == PK_DeviceType_NetworkDevice)
+    {
+        return SendEthRequestBig(device);
+    }
+
+#ifdef POKEYSLIB_USE_LIBUSB
+    if (device->connectionType == PK_DeviceType_FastUSBDevice)
+        return SendRequestFastUSB_multiPart(device);
+    else
+        return PK_ERR_TRANSFER;
+#else
+    return PK_ERR_TRANSFER;
+#endif
+}
+
+int32_t SendRequest(sPoKeysDevice* device)
+{
+    uint32_t waits = 0;
+    uint32_t retries = 0;
+    int32_t result = 0;
+    uint8_t bufferOut[65] = {0};
+
+    hid_device * devHandle;
+
+    if (device == NULL) return PK_ERR_GENERIC;
+    if (device->connectionType == PK_DeviceType_NetworkDevice)
+    {
+        return SendEthRequest(device);
+    }
+#ifdef POKEYSLIB_USE_LIBUSB
+        if (device->connectionType == PK_DeviceType_FastUSBDevice)
+            return SendRequestFastUSB(device);
+#endif
+    devHandle = (hid_device*)device->devHandle;
+
+    if (devHandle == NULL) return PK_ERR_GENERIC;
+
+    while (retries++ < 2)
+    {
+        device->request[0] = 0xBB;
+        device->request[6] = ++device->requestID;
+        device->request[7] = getChecksum(device->request);
+
+        memcpy(bufferOut + 1, device->request, 64);
+
+        result = hid_write(devHandle, bufferOut, 65);
+
+        if (result < 0)
+        {
+            retries++;
+            continue;
+        }
+
+        waits = 0;
+
+        while (waits++ < 50)
+        {
+            result = hid_read(devHandle, device->response, 65);
+
+            if (result < 0)
+            {
+                    break;
+            }
+
+                if (device->response[0] == 0xAA && device->response[6] == device->requestID)
+                {
+                    if (device->response[7] == getChecksum(device->response))
+                    {
+                        LastRetryCount = retries;
+                        LastWaitCount = waits;
+                        return PK_OK;
+                    }
+                }
+            }
+    }
+
+    return PK_ERR_TRANSFER;
+}
+
+int32_t SendRequest_NoResponse(sPoKeysDevice* device)
+{
+    uint32_t waits = 0;
+    uint32_t retries = 0;
+    int32_t result = 0;
+    uint8_t bufferOut[65] = {0};
+
+    hid_device * devHandle;
+
+    if (device == NULL) return PK_ERR_GENERIC;
+    if (device->connectionType == PK_DeviceType_NetworkDevice)
+    {
+        return SendEthRequest_NoResponse(device);
+    }
+#ifdef POKEYSLIB_USE_LIBUSB
+        if (device->connectionType == PK_DeviceType_FastUSBDevice)
+            return SendRequestFastUSB_NoResponse(device);
+#endif
+    devHandle = (hid_device*)device->devHandle;
+
+    if (devHandle == NULL) return PK_ERR_GENERIC;
+
+    while (retries++ < 2)
+    {
+        device->request[0] = 0xBB;
+        device->request[6] = ++device->requestID;
+        device->request[7] = getChecksum(device->request);
+
+        memcpy(bufferOut + 1, device->request, 64);
+
+        result = hid_write(devHandle, bufferOut, 65);
+
+        if (result < 0)
+        {
+            retries++;
+            continue;
+        }
+    }
+
+    return PK_ERR_TRANSFER;
+}
+
+void PK_SL_SetPinFunction(sPoKeysDevice* device, uint8_t pin, uint8_t function)
+{
+    device->Pins[pin].PinFunction = function;
+}
+
+uint8_t PK_SL_GetPinFunction(sPoKeysDevice* device, uint8_t pin)
+{
+    return device->Pins[pin].PinFunction;
+}
+
+void PK_SL_DigitalOutputSet(sPoKeysDevice* device, uint8_t pin, uint8_t value)
+{
+    device->Pins[pin].DigitalValueSet = value;
+}
+
+uint8_t PK_SL_DigitalInputGet(sPoKeysDevice* device, uint8_t pin)
+{
+    return device->Pins[pin].DigitalValueGet;
+}
+
+uint32_t PK_SL_AnalogInputGet(sPoKeysDevice* device, uint8_t pin)
+{
+    return device->Pins[pin].AnalogValue;
+}

--- a/PoKeysLibCoreSocketsAsync.c
+++ b/PoKeysLibCoreSocketsAsync.c
@@ -514,5 +514,218 @@ int PK_SendEthRequestBigAsync(sPoKeysDevice* device)
      return PK_OK;
  }
 
+ /**
+ * @brief Disconnects from a PoKeys network device asynchronously.
+ *
+ * This function closes the non-blocking UDP socket and releases any allocated memory
+ * associated with the device connection.
+ *
+ * @param device Pointer to the sPoKeysDevice structure.
+ *
+ * @note
+ * - This function is non-blocking and safe for use inside a realtime loop.
+ * - It ensures that all resources are properly released.
+ * - The device structure itself is not freed, only the connection-related resources.
+ *
+ * @see PK_ConnectToNetworkDeviceAsync()
+ */
+void PK_DisconnectNetworkDeviceAsync(sPoKeysDevice* device)
+{
+    if (device == NULL || device->connectionType != PK_DeviceType_NetworkDevice)
+        return;
 
+    if (device->devHandle != NULL)
+    {
+        close(*(int*)device->devHandle);
+        hal_free(device->devHandle);
+        device->devHandle = NULL;
+    }
 
+    if (device->devHandle2 != NULL)
+    {
+        hal_free(device->devHandle2);
+        device->devHandle2 = NULL;
+    }
+}
+
+ /**
+ * @brief Sends a PoKeys request packet asynchronously without expecting a response (fire-and-forget).
+ *
+ * Prepares a UDP packet with correct formatting (start byte, request ID, checksum) and 
+ * sends it once over the network to the PoKeys device. No response is waited for.
+ *
+ * This is typically used for operations where the device executes the command
+ * without sending a confirmation (e.g., certain control or update commands).
+ *
+ * @param device Pointer to the sPoKeysDevice structure.
+ *
+ * @return PK_OK if the packet was sent successfully (64 bytes transmitted),
+ *         PK_ERR_TRANSFER if sending failed,
+ *         PK_ERR_GENERIC if device pointer or connection is invalid.
+ *
+ * @note
+ * - The socket must be pre-configured and connected via PK_ConnectToNetworkDeviceAsync().
+ * - No retries or waiting are done inside this function (caller must handle retries if needed).
+ * - Works in realtime-safe LinuxCNC HAL loops (non-blocking sendto()).
+ *
+ * @usage
+ * - Prepare your device connection first.
+ * - Then call PK_SendEthRequestNoResponseAsync() whenever you need to trigger an action without awaiting feedback.
+ *
+ * @see PK_ConnectToNetworkDeviceAsync()
+ * @see PK_SendEthRequestAsync()
+ */
+ int PK_SendEthRequestNoResponseAsync(sPoKeysDevice* device)
+ {
+     if (device == NULL || device->devHandle == NULL)
+         return PK_ERR_GENERIC;
+ 
+     device->requestID++;
+ 
+     device->request[0] = 0xBB;
+     device->request[6] = device->requestID;
+     device->request[7] = getChecksum(device->request);
+ 
+     ssize_t sent = sendto(*(int*)device->devHandle,
+                           device->request, 64, 0,
+                           (struct sockaddr*)device->devHandle2,
+                           sizeof(struct sockaddr_in));
+ 
+     if (sent != 64)
+         return PK_ERR_TRANSFER;
+ 
+     return PK_OK;
+ }
+
+ /**
+ * @brief Sends a large (multi-part) PoKeys request asynchronously (non-blocking).
+ *
+ * This function splits a prepared PoKeys request into 8 × 64-byte segments and
+ * sends them as a single 512-byte UDP packet to the target device.
+ *
+ * This is typically used for sending larger payloads like motion buffers or extended data.
+ *
+ * @param device Pointer to the sPoKeysDevice structure, with valid multiPartData populated.
+ *
+ * @return PK_OK if the multi-part packet was sent successfully (512 bytes transmitted),
+ *         PK_ERR_TRANSFER if sending failed,
+ *         PK_ERR_GENERIC if device or buffers are invalid.
+ *
+ * @note
+ * - No retries or blocking waits are performed inside this function.
+ * - Only works with UDP connections (TCP not supported for multi-part transfers).
+ * - Make sure `device->multiPartData` is filled with 448 bytes of payload data before calling.
+ *
+ * @see PK_RecvEthBigResponseAsync()
+ */
+int PK_SendEthRequestBigAsync(sPoKeysDevice* device)
+{
+    if (device == NULL || device->multiPartBuffer == NULL || device->devHandle == NULL)
+        return PK_ERR_GENERIC;
+
+    // Fill 8 × 64-byte parts
+    for (uint32_t i = 0; i < 8; i++)
+    {
+        uint8_t* p = &device->multiPartBuffer[i * 64];
+
+        memcpy(p, device->request, 8);
+        p[0] = 0xBB;
+        p[2] = i;
+        if (i == 0) p[2] |= (1 << 3); // First
+        if (i == 7) p[2] |= (1 << 4); // Last
+
+        p[6] = ++device->requestID;
+        p[7] = getChecksum(p);
+
+        memcpy(p + 8, device->multiPartData + (i * 56), 56);
+    }
+
+    // Send entire 512-byte buffer
+    ssize_t sent = sendto(*(int*)device->devHandle,
+                          device->multiPartBuffer, 512, 0,
+                          (struct sockaddr*)device->devHandle2,
+                          sizeof(struct sockaddr_in));
+
+    return (sent == 512) ? PK_OK : PK_ERR_TRANSFER;
+}
+
+/**
+ * @brief Receives the response to a large (multi-part) PoKeys request asynchronously.
+ *
+ * After sending a multi-part request with PK_SendEthRequestBigAsync(), this function
+ * checks (non-blocking) if a valid response packet from the device is available.
+ *
+ * Verifies packet start byte, request ID match, and checksum integrity.
+ *
+ * @param device Pointer to the sPoKeysDevice structure.
+ *
+ * @return PK_OK if a valid 64-byte response packet was received,
+ *         PK_ERR_AGAIN if no packet is available yet (socket would block),
+ *         PK_ERR_TRANSFER if packet received is invalid or corrupted.
+ *
+ * @note
+ * - Intended for use inside a polling loop after a big request was sent.
+ * - No retries or waiting are performed internally (caller should retry if necessary).
+ * - This method is realtime-safe and non-blocking.
+ *
+ * @see PK_SendEthRequestBigAsync()
+ */
+ int PK_RecvEthBigResponseAsync(sPoKeysDevice* device)
+ {
+     if (device == NULL || device->devHandle == NULL)
+         return PK_ERR_GENERIC;
+ 
+     unsigned char tmpbuf[64];
+     ssize_t received = recv(*(int*)device->devHandle, tmpbuf, sizeof(tmpbuf), MSG_DONTWAIT);
+ 
+     if (received < 0)
+     {
+         if (errno == EAGAIN || errno == EWOULDBLOCK)
+             return PK_ERR_AGAIN;
+         else
+             return PK_ERR_TRANSFER;
+     }
+ 
+     if (received != 64)
+         return PK_ERR_TRANSFER;
+ 
+     if (tmpbuf[0] != 0xAA || tmpbuf[6] != device->requestID || tmpbuf[7] != getChecksum(tmpbuf))
+         return PK_ERR_TRANSFER;
+ 
+     memcpy(device->response, tmpbuf, 64);
+     return PK_OK;
+ }
+
+ /**
+ * @brief Disconnects from a PoKeys network device asynchronously.
+ *
+ * This function closes the non-blocking UDP socket and releases any allocated memory
+ * associated with the device connection.
+ *
+ * @param device Pointer to the sPoKeysDevice structure.
+ *
+ * @note
+ * - This function is non-blocking and safe for use inside a realtime loop.
+ * - It ensures that all resources are properly released.
+ * - The device structure itself is not freed, only the connection-related resources.
+ *
+ * @see PK_ConnectToNetworkDeviceAsync()
+ */
+void PK_DisconnectNetworkDeviceAsync(sPoKeysDevice* device)
+{
+    if (device == NULL || device->connectionType != PK_DeviceType_NetworkDevice)
+        return;
+
+    if (device->devHandle != NULL)
+    {
+        close(*(int*)device->devHandle);
+        hal_free(device->devHandle);
+        device->devHandle = NULL;
+    }
+
+    if (device->devHandle2 != NULL)
+    {
+        hal_free(device->devHandle2);
+        device->devHandle2 = NULL;
+    }
+}


### PR DESCRIPTION
Add missing asynchronous functions to `PoKeysLibCoreAsync.c` to replicate synchronous logic.

* **New Functions**: Add `PK_EnumerateUSBDevices`, `PK_GetCurrentDeviceConnectionType`, `InitializeNewDevice`, `CleanDevice`, `PK_ReleaseDeviceStructure`, `PK_CloneDeviceStructure`, `PK_FastUSBConnectToDevice`, `PK_ConnectToDevice`, `PK_ConnectToPoKeysDevice_USB`, `PK_ConnectToPoKeysDevice_Ethernet`, `PK_ConnectToPoKeysDevice`, `PK_ConnectToDeviceWSerial`, `PK_ConnectToDeviceWSerial_UDP`, `PK_DisconnectDevice`, `CreateRequest`, `PK_CustomRequest`, `getChecksum`, `SendRequest_multiPart`, `SendRequest`, `SendRequest_NoResponse`, `PK_SL_SetPinFunction`, `PK_SL_GetPinFunction`, `PK_SL_DigitalOutputSet`, `PK_SL_DigitalInputGet`, `PK_SL_AnalogInputGet`.
* **Memory Management**: Use `malloc` and `free` for memory allocation and deallocation in new functions.
* **Non-blocking Calls**: Ensure all new functions use non-blocking calls where applicable.
* **Device Initialization**: Implement device initialization and cleanup logic in `InitializeNewDevice` and `CleanDevice`.
* **Device Connection**: Implement device connection logic in `PK_ConnectToDevice`, `PK_ConnectToPoKeysDevice_USB`, `PK_ConnectToPoKeysDevice_Ethernet`, `PK_ConnectToPoKeysDevice`, `PK_ConnectToDeviceWSerial`, `PK_ConnectToDeviceWSerial_UDP`.
* **Request Handling**: Implement request creation and handling logic in `CreateRequest`, `PK_CustomRequest`, `SendRequest_multiPart`, `SendRequest`, `SendRequest_NoResponse`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/pokeysHal/pull/23?shareId=49f20207-12d0-406f-b001-f56696ee7649).