### PR TITLE
Extend PoKeysLibHal.h by the public functions added in *Async.c files

### DIFF
--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -1347,6 +1347,14 @@ POKEYSDECL int32_t PK_OEM_Martelli_SetRate(sPoKeysDevice* device, uint32_t rate)
 
 extern int32_t LastRetryCount;
 extern int32_t LastWaitCount;
+
+// Asynchronous functions
+POKEYSDECL int PK_EncoderConfigurationGetAsync(sPoKeysDevice* device);
+POKEYSDECL int PK_EncoderConfigurationSetAsync(sPoKeysDevice* device);
+POKEYSDECL int PK_EncoderValuesGetAsync(sPoKeysDevice* device);
+POKEYSDECL int PK_EncoderValuesSetAsync(sPoKeysDevice* device);
+POKEYSDECL int PK_RTCGetAsync(sPoKeysDevice* device);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Extend `PoKeysLibHal.h` to include declarations for new asynchronous functions.

* Add declarations for `PK_EncoderConfigurationGetAsync`, `PK_EncoderConfigurationSetAsync`, `PK_EncoderValuesGetAsync`, `PK_EncoderValuesSetAsync`, and `PK_RTCGetAsync`.
* Insert a new section for asynchronous functions in the header file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/pokeysHal/pull/25?shareId=d306221a-e635-4003-9e69-fd69243f4c6c).