### PR TITLE
Refactor shared async state into a single structure per device

### DIFF
--- a/PoKeysLibAsync.h
+++ b/PoKeysLibAsync.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-
+#include <pthread.h>
 
 #define MAX_TRANSACTIONS 64 // Maximum number of async transactions
 
@@ -67,6 +67,11 @@ typedef struct {
     uint8_t request_buffer[64];
     uint8_t response_buffer[64];
 } mailbox_entry_t;
+
+typedef struct {
+    async_transaction_t transactions[MAX_TRANSACTIONS];
+    pthread_mutex_t mutex;
+} async_state_t;
 
 // Function declarations
 int CreateRequestAsync(sPoKeysDevice *dev, pokeys_command_t cmd,

--- a/PoKeysLibAsync.h
+++ b/PoKeysLibAsync.h
@@ -4,7 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
-#include <pthread.h>
+
 
 #define MAX_TRANSACTIONS 64 // Maximum number of async transactions
 
@@ -68,10 +68,7 @@ typedef struct {
     uint8_t response_buffer[64];
 } mailbox_entry_t;
 
-typedef struct {
-    async_transaction_t transactions[MAX_TRANSACTIONS];
-    pthread_mutex_t mutex;
-} async_state_t;
+
 
 // Function declarations
 int CreateRequestAsync(sPoKeysDevice *dev, pokeys_command_t cmd,

--- a/PoKeysLibAsync.h
+++ b/PoKeysLibAsync.h
@@ -8,65 +8,7 @@
 
 
 
-typedef enum {
-    TRANSACTION_PENDING = 0,
-    TRANSACTION_COMPLETED = 1,
-    TRANSACTION_TIMEOUT = 2,
-    TRANSACTION_FAILED = 3
-} transaction_status_t;
 
-typedef enum {
-    PK_CMD_DIGITAL_INPUTS_GET   = 0x10,
-    PK_CMD_DIGITAL_OUTPUTS_SET  = 0x11,
-    PK_CMD_ANALOG_INPUTS_GET    = 0x20,
-    PK_CMD_ANALOG_OUTPUTS_SET   = 0x21,
-    PK_CMD_ENCODER_VALUES_GET = 0xCD,
-    PK_CMD_ENCODER_VALUES_SET = 0xCD,    // Same as GET but param10/11 means set
-    PK_CMD_ENCODER_OPTION_SET  = 0xC4,
-    PK_CMD_ENCODER_MAPPING_SET = 0xC5,
-    PK_CMD_ENCODER_KEYMAP_A_SET = 0xC6,
-    PK_CMD_ENCODER_KEYMAP_B_SET = 0xC7,
-    PK_CMD_FAST_ENCODERS_SET = 0xCE,
-    PK_CMD_ULTRAFAST_ENCODERS_SET = 0x1C,
-    PK_CMD_ENCODER_TEST_MODE_GET = 0x85,
-    PK_CMD_DEVICE_INFO_GET      = 0x05,
-    // usw...
-} pokeys_command_t;
-
-typedef int (*pokeys_response_parser_t)(sPoKeysDevice *dev, const uint8_t *response);
-
-typedef struct {
-    uint8_t request_buffer[64];
-    uint8_t response_buffer[64];
-    uint8_t request_id;
-    pokeys_command_t command_sent;
-
-    uint64_t timestamp_sent;
-    uint8_t retries_left;
-
-    transaction_status_t status;
-    bool response_ready;
-    // Optional parser
-    int (*response_parser)(sPoKeysDevice *dev, const uint8_t *response);
-
-    void *target_ptr;
-    size_t target_size;
-} async_transaction_t;
-
-typedef struct {
-    uint8_t request_id;
-    pokeys_command_t command_sent;
-    uint64_t timestamp_sent;
-    int retries_left;
-    bool response_ready;
-
-    void *target_ptr;
-    size_t target_size;
-    pokeys_response_parser_t response_parser; // << NEW! Optional per-request parser function
-
-    uint8_t request_buffer[64];
-    uint8_t response_buffer[64];
-} mailbox_entry_t;
 
 
 

--- a/PoKeysLibAsync.h
+++ b/PoKeysLibAsync.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 
 
-#define MAX_TRANSACTIONS 64 // Maximum number of async transactions
+
 
 typedef enum {
     TRANSACTION_PENDING = 0,

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -927,38 +927,7 @@ typedef enum {
 
 
 
-typedef struct {
-    uint8_t request_buffer[64];
-    uint8_t response_buffer[64];
-    uint8_t request_id;
-    pokeys_command_t command_sent;
 
-    uint64_t timestamp_sent;
-    uint8_t retries_left;
-
-    transaction_status_t status;
-    bool response_ready;
-    // Optional parser
-    int (*response_parser)(sPoKeysDevice *dev, const uint8_t *response);
-
-    void *target_ptr;
-    size_t target_size;
-} async_transaction_t;
-
-typedef struct {
-    uint8_t request_id;
-    pokeys_command_t command_sent;
-    uint64_t timestamp_sent;
-    int retries_left;
-    bool response_ready;
-
-    void *target_ptr;
-    size_t target_size;
-    pokeys_response_parser_t response_parser; // << NEW! Optional per-request parser function
-
-    uint8_t request_buffer[64];
-    uint8_t response_buffer[64];
-} mailbox_entry_t;
 
 typedef struct {
     async_transaction_t transactions[MAX_TRANSACTIONS];
@@ -1048,6 +1017,39 @@ typedef struct
 } sPoKeysDevice;
 
 typedef int (*pokeys_response_parser_t)(sPoKeysDevice *dev, const uint8_t *response);
+
+typedef struct {
+    uint8_t request_buffer[64];
+    uint8_t response_buffer[64];
+    uint8_t request_id;
+    pokeys_command_t command_sent;
+
+    uint64_t timestamp_sent;
+    uint8_t retries_left;
+
+    transaction_status_t status;
+    bool response_ready;
+    // Optional parser
+    int (*response_parser)(sPoKeysDevice *dev, const uint8_t *response);
+
+    void *target_ptr;
+    size_t target_size;
+} async_transaction_t;
+
+typedef struct {
+    uint8_t request_id;
+    pokeys_command_t command_sent;
+    uint64_t timestamp_sent;
+    int retries_left;
+    bool response_ready;
+
+    void *target_ptr;
+    size_t target_size;
+    pokeys_response_parser_t response_parser; // << NEW! Optional per-request parser function
+
+    uint8_t request_buffer[64];
+    uint8_t response_buffer[64];
+} mailbox_entry_t;
 
 // Enumerate USB devices. Returns number of USB devices detected.
 #ifndef RTAPI

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -52,7 +52,7 @@
 #if !defined(RTAPI) && !defined(ULAPI)
 #define ULAPI
 #endif
-
+#include <pthread.h>
 #include "hal.h" // Make sure to include LinuxCNC's hal.h first
 
 //#define USE_ALIGN_TEST
@@ -898,6 +898,10 @@ typedef struct
  uint8_t bFailSafePWM[6];                                 // PWM outputs values
 } sPoKeysFailsafeSettings;
 
+typedef struct {
+    async_transaction_t transactions[MAX_TRANSACTIONS];
+    pthread_mutex_t mutex;
+} async_state_t;
 
 // Main PoKeys structure
 typedef struct

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -925,7 +925,7 @@ typedef enum {
     // usw...
 } pokeys_command_t;
 
-typedef int (*pokeys_response_parser_t)(sPoKeysDevice *dev, const uint8_t *response);
+
 
 typedef struct {
     uint8_t request_buffer[64];
@@ -1047,6 +1047,7 @@ typedef struct
  
 } sPoKeysDevice;
 
+typedef int (*pokeys_response_parser_t)(sPoKeysDevice *dev, const uint8_t *response);
 
 // Enumerate USB devices. Returns number of USB devices detected.
 #ifndef RTAPI

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -53,7 +53,7 @@
 #define ULAPI
 #endif
 #include <pthread.h>
-#include "PoKeysLibAsync.h"
+
 #include "hal.h" // Make sure to include LinuxCNC's hal.h first
 #define MAX_TRANSACTIONS 256 // Maximum number of async transactions
 
@@ -899,6 +899,66 @@ typedef struct
  uint8_t bFailSafePoExtBus[10];                           // PoExtBus outputs values
  uint8_t bFailSafePWM[6];                                 // PWM outputs values
 } sPoKeysFailsafeSettings;
+
+typedef enum {
+    TRANSACTION_PENDING = 0,
+    TRANSACTION_COMPLETED = 1,
+    TRANSACTION_TIMEOUT = 2,
+    TRANSACTION_FAILED = 3
+} transaction_status_t;
+
+typedef enum {
+    PK_CMD_DIGITAL_INPUTS_GET   = 0x10,
+    PK_CMD_DIGITAL_OUTPUTS_SET  = 0x11,
+    PK_CMD_ANALOG_INPUTS_GET    = 0x20,
+    PK_CMD_ANALOG_OUTPUTS_SET   = 0x21,
+    PK_CMD_ENCODER_VALUES_GET = 0xCD,
+    PK_CMD_ENCODER_VALUES_SET = 0xCD,    // Same as GET but param10/11 means set
+    PK_CMD_ENCODER_OPTION_SET  = 0xC4,
+    PK_CMD_ENCODER_MAPPING_SET = 0xC5,
+    PK_CMD_ENCODER_KEYMAP_A_SET = 0xC6,
+    PK_CMD_ENCODER_KEYMAP_B_SET = 0xC7,
+    PK_CMD_FAST_ENCODERS_SET = 0xCE,
+    PK_CMD_ULTRAFAST_ENCODERS_SET = 0x1C,
+    PK_CMD_ENCODER_TEST_MODE_GET = 0x85,
+    PK_CMD_DEVICE_INFO_GET      = 0x05,
+    // usw...
+} pokeys_command_t;
+
+typedef int (*pokeys_response_parser_t)(sPoKeysDevice *dev, const uint8_t *response);
+
+typedef struct {
+    uint8_t request_buffer[64];
+    uint8_t response_buffer[64];
+    uint8_t request_id;
+    pokeys_command_t command_sent;
+
+    uint64_t timestamp_sent;
+    uint8_t retries_left;
+
+    transaction_status_t status;
+    bool response_ready;
+    // Optional parser
+    int (*response_parser)(sPoKeysDevice *dev, const uint8_t *response);
+
+    void *target_ptr;
+    size_t target_size;
+} async_transaction_t;
+
+typedef struct {
+    uint8_t request_id;
+    pokeys_command_t command_sent;
+    uint64_t timestamp_sent;
+    int retries_left;
+    bool response_ready;
+
+    void *target_ptr;
+    size_t target_size;
+    pokeys_response_parser_t response_parser; // << NEW! Optional per-request parser function
+
+    uint8_t request_buffer[64];
+    uint8_t response_buffer[64];
+} mailbox_entry_t;
 
 typedef struct {
     async_transaction_t transactions[MAX_TRANSACTIONS];

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -53,6 +53,7 @@
 #define ULAPI
 #endif
 #include <pthread.h>
+#include PoKeysLibAsync.h
 #include "hal.h" // Make sure to include LinuxCNC's hal.h first
 #define MAX_TRANSACTIONS 256 // Maximum number of async transactions
 

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -53,7 +53,7 @@
 #define ULAPI
 #endif
 #include <pthread.h>
-#include PoKeysLibAsync.h
+#include "PoKeysLibAsync.h"
 #include "hal.h" // Make sure to include LinuxCNC's hal.h first
 #define MAX_TRANSACTIONS 256 // Maximum number of async transactions
 

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -54,6 +54,7 @@
 #endif
 #include <pthread.h>
 #include "hal.h" // Make sure to include LinuxCNC's hal.h first
+#define MAX_TRANSACTIONS 256 // Maximum number of async transactions
 
 //#define USE_ALIGN_TEST
 

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -977,6 +977,7 @@ typedef struct
  // extended for Async
  uint8_t rtc_response_buffer[64]; // in sPoKeysDevice
 
+ async_state_t* async_state; // Pointer to async_state_t structure
  
 } sPoKeysDevice;
 


### PR DESCRIPTION
Refactor shared async state management into a single structure per device.

* Add `async_state_t` structure in `PoKeysLibAsync.h` to encapsulate task queue, retries, and mutex.
* Modify `sPoKeysDevice` in `PoKeysLibHal.h` to include a pointer to `async_state_t`.
* Refactor functions in `PoKeysLibAsync.c` to use the new `async_state_t` structure for managing async transactions.
  - Update `transaction_alloc` and `transaction_find` to use `async_state_t`.
  - Modify `CreateRequestAsync`, `SendRequestAsync`, and `PK_ReceiveAndDispatch` to use `async_state_t`.
  - Update `PK_TimeoutAndRetryCheck` to use `async_state_t`.
* Update `PoKeysLibCoreAsync.c` to initialize and manage `async_state_t` for each device during connection.
  - Initialize `async_state_t` in `PK_InitDeviceAsync`.
  - Clean up `async_state_t` in `PK_CleanDeviceAsync`.
  - Clone `async_state_t` in `PK_CloneDeviceStructureAsync`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zarfld/pokeysHal/pull/31?shareId=864cf14f-7d65-4dca-98a3-0314a8d85f62).