### PR TITLE
Refactor CreateRequest enums

### DIFF
--- a/PoKeysLib1Wire.c
+++ b/PoKeysLib1Wire.c
@@ -20,12 +20,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_1WireStatusSet(sPoKeysDevice* device, uint8_t activated)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, activated, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, activated, 0, 0, 0);
     return SendRequest(device);
 }
 
@@ -33,7 +34,7 @@ int32_t PK_1WireStatusGet(sPoKeysDevice* device, uint8_t* activated)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, 0x11, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x11, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *activated = device->response[3];
@@ -48,7 +49,7 @@ int32_t PK_1WireWriteReadStart(sPoKeysDevice* device, uint8_t WriteCount, uint8_
     if (WriteCount > 16) WriteCount = 16;
     if (ReadCount > 16) ReadCount = 16;
 
-    CreateRequest(device->request, 0xDC, 0x10, WriteCount, ReadCount, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x10, WriteCount, ReadCount, 0);
     for (i = 0; i < WriteCount; i++)
     {
         device->request[8+i] = data[i];
@@ -61,7 +62,7 @@ int32_t PK_1WireReadStatusGet(sPoKeysDevice* device, uint8_t * readStatus, uint8
     uint32_t i;
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, 0x11, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x11, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *readStatus = device->response[8];
@@ -93,7 +94,7 @@ int32_t PK_1WireWriteReadStartEx(sPoKeysDevice* device, uint8_t pinID, uint8_t W
     if (WriteCount > 16) WriteCount = 16;
     if (ReadCount > 16) ReadCount = 16;
 
-    CreateRequest(device->request, 0xDC, 0x10, WriteCount, ReadCount, pinID);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x10, WriteCount, ReadCount, pinID);
     for (i = 0; i < WriteCount; i++)
     {
         device->request[8+i] = data[i];
@@ -106,7 +107,7 @@ int32_t PK_1WireBusScanStart(sPoKeysDevice* device, uint8_t pinID)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, 0x20, pinID, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x20, pinID, 0, 0);
     return SendRequest(device);
 }
 
@@ -114,7 +115,7 @@ int32_t PK_1WireBusScanGetResults(sPoKeysDevice* device, uint8_t * operationStat
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, 0x21, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x21, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *operationStatus = device->response[8];
@@ -130,7 +131,7 @@ int32_t PK_1WireBusScanContinue(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, 0x22, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x22, 0, 0, 0);
     return SendRequest(device);
 }
 
@@ -139,7 +140,7 @@ int32_t PK_1WireBusScanStop(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDC, 0x23, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_ONEWIRE_COMMUNICATION, 0x23, 0, 0, 0);
     return SendRequest(device);
 }
 

--- a/PoKeysLibCAN.c
+++ b/PoKeysLibCAN.c
@@ -19,13 +19,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_CANConfigure(sPoKeysDevice* device, uint32_t bitrate)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure UART
-    CreateRequest(device->request, 0x86, 0x01, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_CAN_OPERATIONS, POCAN_CMD_ENABLE, 0, 0, 0);
     *(uint32_t*)(device->request + 8) = bitrate;
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
@@ -36,7 +37,7 @@ int32_t PK_CANRegisterFilter(sPoKeysDevice* device, uint8_t format, uint32_t CAN
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure UART
-    CreateRequest(device->request, 0x86, 0x10, format, 0, 0);
+    CreateRequest(device->request, PK_CMD_CAN_OPERATIONS, 0x10, format, 0, 0);
     *(uint32_t*)(device->request + 8) = CANid;
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
@@ -47,7 +48,7 @@ int32_t PK_CANWrite(sPoKeysDevice* device, sPoKeysCANmsg * msg)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure UART
-    CreateRequest(device->request, 0x86, 0x20, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_CAN_OPERATIONS, 0x20, 0, 0, 0);
     memcpy(device->request + 8, msg, sizeof(sPoKeysCANmsg));
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
@@ -58,7 +59,7 @@ int32_t PK_CANRead(sPoKeysDevice* device, sPoKeysCANmsg * msg, uint8_t * status)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure UART
-    CreateRequest(device->request, 0x86, 0x31, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_CAN_OPERATIONS, 0x31, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *status = device->response[3];
@@ -73,7 +74,7 @@ int32_t PK_CANFlush(sPoKeysDevice* device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure UART
-    CreateRequest(device->request, 0x86, 0x32, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_CAN_OPERATIONS, 0x32, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }

--- a/PoKeysLibCANAsync.c
+++ b/PoKeysLibCANAsync.c
@@ -40,7 +40,7 @@ int PK_CANConfigureAsync(sPoKeysDevice* device, uint32_t bitrate)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x01 };
-    int req = CreateRequestAsyncWithPayload(device, 0x86, params, 1,
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_CAN_OPERATIONS, params, 1,
                                             &bitrate, sizeof(uint32_t), NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
@@ -50,7 +50,7 @@ int PK_CANRegisterFilterAsync(sPoKeysDevice* device, uint8_t format, uint32_t CA
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[2] = { 0x10, format };
-    int req = CreateRequestAsyncWithPayload(device, 0x86, params, 2,
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_CAN_OPERATIONS, params, 2,
                                             &CANid, sizeof(uint32_t), NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
@@ -60,7 +60,7 @@ int PK_CANWriteAsync(sPoKeysDevice* device, sPoKeysCANmsg *msg)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x20 };
-    int req = CreateRequestAsyncWithPayload(device, 0x86, params, 1,
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_CAN_OPERATIONS, params, 1,
                                             msg, sizeof(sPoKeysCANmsg), NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
@@ -70,7 +70,7 @@ int PK_CANReadAsync(sPoKeysDevice* device, sPoKeysCANmsg *msg, uint8_t *status)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x31 };
-    int req = CreateRequestAsync(device, 0x86, params, 1,
+    int req = CreateRequestAsync(device, PK_CMD_CAN_OPERATIONS, params, 1,
                                  NULL, 0, PK_CANRead_Parse);
     if (req < 0) return req;
     can_ctx[req].status_ptr = status;
@@ -83,7 +83,7 @@ int PK_CANFlushAsync(sPoKeysDevice* device)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x32 };
-    int req = CreateRequestAsync(device, 0x86, params, 1, NULL, 0, NULL);
+    int req = CreateRequestAsync(device, PK_CMD_CAN_OPERATIONS, params, 1, NULL, 0, NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
 }

--- a/PoKeysLibEncoders.c
+++ b/PoKeysLibEncoders.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_EncoderConfigurationGet(sPoKeysDevice* device)
 {
@@ -227,7 +228,7 @@ int32_t PK_EncoderValuesGet(sPoKeysDevice* device)
 		} else return PK_ERR_TRANSFER;
 		
 		// Read the test mode values for the ultra-fast encoder
-		CreateRequest(device->request, 0x85, 0x37, 0, 0, 0);
+                CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_ENCODER_TEST_RESULTS, 0, 0, 0);
 		if (SendRequest(device) == PK_OK)
 		{
 			device->PEv2.EncoderIndexCount = *((uint32_t*)&device->response[12]);

--- a/PoKeysLibEncodersAsync.c
+++ b/PoKeysLibEncodersAsync.c
@@ -495,9 +495,9 @@ int PK_EncoderConfigurationGetAsync(sPoKeysDevice* device)
  
              // Read UltraFast encoder extra values
              uint8_t params_ultrafast[] = {0x37}; // Sub-command for test mode
-             CreateRequestAsync(device, 0x85, params_ultrafast, 1,
-                 NULL, 0,
-                 PK_EncoderValuesGetAsync_ProcessUltraFast);
+            CreateRequestAsync(device, PK_CMD_PULSE_ENGINE_V2, params_ultrafast, 1,
+                NULL, 0,
+                PK_EncoderValuesGetAsync_ProcessUltraFast);
          }
          else
          {

--- a/PoKeysLibI2C.c
+++ b/PoKeysLibI2C.c
@@ -20,13 +20,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 
 int32_t PK_I2CSetStatus(sPoKeysDevice* device, uint8_t activated)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDB, activated, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, activated, 0, 0, 0);
     return SendRequest(device);
 }
 
@@ -34,7 +35,7 @@ int32_t PK_I2CGetStatus(sPoKeysDevice* device, uint8_t* activated) // Retrieves 
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDB, 0x02, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x02, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *activated = device->response[3];
@@ -48,7 +49,7 @@ int32_t PK_I2CWriteStart(sPoKeysDevice* device, uint8_t address, uint8_t* buffer
 
     if (iDataLength > 32) iDataLength = 32;
 
-    CreateRequest(device->request, 0xDB, 0x10, address, iDataLength, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x10, address, iDataLength, 0);
     for (i = 0; i < iDataLength; i++)
     {
         device->request[8+i] = buffer[i];
@@ -63,7 +64,7 @@ int32_t PK_I2CWriteAndReadStart(sPoKeysDevice* device, uint8_t address, uint8_t*
 
     if (iDataLengthWrite > 32) iDataLengthWrite = 32;
 
-    CreateRequest(device->request, 0xDB, 0x10, address, iDataLengthWrite, iDataLengthRead);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x10, address, iDataLengthWrite, iDataLengthRead);
     for (i = 0; i < iDataLengthWrite; i++)
     {
         device->request[8+i] = buffer[i];
@@ -75,7 +76,7 @@ int32_t PK_I2CWriteStatusGet(sPoKeysDevice* device, uint8_t* status)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDB, 0x11, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x11, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *status = device->response[3];
@@ -88,7 +89,7 @@ int32_t PK_I2CReadStart(sPoKeysDevice* device, uint8_t address, uint8_t iDataLen
 
     if (iDataLength > 32) iDataLength = 32;
 
-    CreateRequest(device->request, 0xDB, 0x20, address, iDataLength, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x20, address, iDataLength, 0);
     return SendRequest(device);
 }
 
@@ -98,7 +99,7 @@ int32_t PK_I2CReadStatusGet(sPoKeysDevice* device, uint8_t* status, uint8_t* iRe
 
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDB, 0x21, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x21, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *status = device->response[3];
@@ -126,7 +127,7 @@ int32_t PK_I2CBusScanStart(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDB, 0x30, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x30, 0, 0, 0);
     return SendRequest(device);
 }
 
@@ -138,7 +139,7 @@ int32_t PK_I2CBusScanGetResults(sPoKeysDevice* device, uint8_t* status, uint8_t*
 
     if (iMaxDevices > 128) iMaxDevices = 128;
 
-    CreateRequest(device->request, 0xDB, 0x31, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_I2C_COMMUNICATION, 0x31, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *status = device->response[3];

--- a/PoKeysLibI2CAsync.c
+++ b/PoKeysLibI2CAsync.c
@@ -66,7 +66,7 @@ int PK_I2CSetStatusAsync(sPoKeysDevice* device, uint8_t activated)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { activated };
-    int req = CreateRequestAsync(device, 0xDB, params, 1, NULL, 0, NULL);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 1, NULL, 0, NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
 }
@@ -75,7 +75,7 @@ int PK_I2CGetStatusAsync(sPoKeysDevice* device, uint8_t* activated)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x02 };
-    int req = CreateRequestAsync(device, 0xDB, params, 1, NULL, 0, PK_I2C_StatusParse);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 1, NULL, 0, PK_I2C_StatusParse);
     if (req < 0) return req;
     i2c_ctx[req].status_ptr = activated;
     i2c_ctx[req].used = 1;
@@ -87,7 +87,7 @@ int PK_I2CWriteStartAsync(sPoKeysDevice* device, uint8_t address, uint8_t* buffe
     if (!device) return PK_ERR_NOT_CONNECTED;
     if (iDataLength > 32) iDataLength = 32;
     uint8_t params[3] = { 0x10, address, iDataLength };
-    int req = CreateRequestAsyncWithPayload(device, 0xDB, params, 3, buffer, iDataLength, NULL);
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_I2C_COMMUNICATION, params, 3, buffer, iDataLength, NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
 }
@@ -97,7 +97,7 @@ int PK_I2CWriteAndReadStartAsync(sPoKeysDevice* device, uint8_t address, uint8_t
     if (!device) return PK_ERR_NOT_CONNECTED;
     if (iDataLengthWrite > 32) iDataLengthWrite = 32;
     uint8_t params[4] = { 0x10, address, iDataLengthWrite, iDataLengthRead };
-    int req = CreateRequestAsyncWithPayload(device, 0xDB, params, 4, buffer, iDataLengthWrite, NULL);
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_I2C_COMMUNICATION, params, 4, buffer, iDataLengthWrite, NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
 }
@@ -106,7 +106,7 @@ int PK_I2CWriteStatusGetAsync(sPoKeysDevice* device, uint8_t* status)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x11 };
-    int req = CreateRequestAsync(device, 0xDB, params, 1, NULL, 0, PK_I2C_StatusParse);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 1, NULL, 0, PK_I2C_StatusParse);
     if (req < 0) return req;
     i2c_ctx[req].status_ptr = status;
     i2c_ctx[req].used = 1;
@@ -118,7 +118,7 @@ int PK_I2CReadStartAsync(sPoKeysDevice* device, uint8_t address, uint8_t iDataLe
     if (!device) return PK_ERR_NOT_CONNECTED;
     if (iDataLength > 32) iDataLength = 32;
     uint8_t params[3] = { 0x20, address, iDataLength };
-    int req = CreateRequestAsync(device, 0xDB, params, 3, NULL, 0, NULL);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 3, NULL, 0, NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
 }
@@ -127,7 +127,7 @@ int PK_I2CReadStatusGetAsync(sPoKeysDevice* device, uint8_t* status, uint8_t* iR
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x21 };
-    int req = CreateRequestAsync(device, 0xDB, params, 1, NULL, 0, PK_I2C_ReadStatusParse);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 1, NULL, 0, PK_I2C_ReadStatusParse);
     if (req < 0) return req;
     i2c_ctx[req].status_ptr = status;
     i2c_ctx[req].read_bytes_ptr = iReadBytes;
@@ -141,7 +141,7 @@ int PK_I2CBusScanStartAsync(sPoKeysDevice* device)
 {
     if (!device) return PK_ERR_NOT_CONNECTED;
     uint8_t params[1] = { 0x30 };
-    int req = CreateRequestAsync(device, 0xDB, params, 1, NULL, 0, NULL);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 1, NULL, 0, NULL);
     if (req < 0) return req;
     return SendRequestAsync(device, req);
 }
@@ -151,7 +151,7 @@ int PK_I2CBusScanGetResultsAsync(sPoKeysDevice* device, uint8_t* status, uint8_t
     if (!device) return PK_ERR_NOT_CONNECTED;
     if (iMaxDevices > 128) iMaxDevices = 128;
     uint8_t params[1] = { 0x31 };
-    int req = CreateRequestAsync(device, 0xDB, params, 1, NULL, 0, PK_I2C_BusScanParse);
+    int req = CreateRequestAsync(device, PK_CMD_I2C_COMMUNICATION, params, 1, NULL, 0, PK_I2C_BusScanParse);
     if (req < 0) return req;
     i2c_ctx[req].status_ptr = status;
     i2c_ctx[req].scan_results_ptr = presentDevices;

--- a/PoKeysLibLCD.c
+++ b/PoKeysLibLCD.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_LCDConfigurationGet(sPoKeysDevice* device)
 {	
@@ -27,7 +28,7 @@ int32_t PK_LCDConfigurationGet(sPoKeysDevice* device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD0, 1, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_CONFIGURATION, 1, 0, 0, 0);
 	if (SendRequest(device) == PK_OK)
     {
 		device->LCD.Configuration = device->response[3];
@@ -44,15 +45,15 @@ int32_t PK_LCDConfigurationSet(sPoKeysDevice* device)
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
     // Set LCD configuration
-    CreateRequest(device->request, 0xD0, 0, device->LCD.Configuration, device->LCD.Rows, device->LCD.Columns);
+    CreateRequest(device->request, PK_CMD_LCD_CONFIGURATION, 0, device->LCD.Configuration, device->LCD.Rows, device->LCD.Columns);
 	if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     // Initialize LCD
-    CreateRequest(device->request, 0xD1, 0, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     // Clear LCD
-    CreateRequest(device->request, 0xD1, 0x10, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x10, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
 
@@ -77,7 +78,7 @@ int32_t PK_LCDUpdate(sPoKeysDevice* device)
 	{
 		if (device->LCD.RowRefreshFlags & (1<<n))
 		{
-			CreateRequest(device->request, 0xD1, 0x85, n + 1, 0, 0);
+                    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x85, n + 1, 0, 0);
 			for (i = 0; i < 20; i++)
 			{
                 device->request[8 + i] = lines[n][i];
@@ -99,7 +100,7 @@ int32_t PK_LCDSetCustomCharacters(sPoKeysDevice* device)
     // Update LCD custom characters
     for (n = 0; n < 8; n++)
     {
-        CreateRequest(device->request, 0xD1, 0x40, 0, 0, 0);
+        CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x40, 0, 0, 0);
         device->request[8] = n;
         for (i = 0; i < 8; i++)
         {
@@ -116,7 +117,7 @@ int32_t PK_LCDChangeMode(sPoKeysDevice* device, uint8_t mode)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0x80, mode, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x80, mode, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }
@@ -128,7 +129,7 @@ int32_t PK_LCDInit(sPoKeysDevice* device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }
@@ -138,7 +139,7 @@ int32_t PK_LCDClear(sPoKeysDevice* device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0x10, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x10, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }
@@ -148,7 +149,7 @@ int32_t PK_LCDMoveCursor(sPoKeysDevice* device, uint8_t row, uint8_t column)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0x20, column, row, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x20, column, row, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }
@@ -161,7 +162,7 @@ int32_t PK_LCDPrint(sPoKeysDevice* device, uint8_t * text, uint8_t textLen)
 
     if (textLen > 20) textLen = 20;
 
-    CreateRequest(device->request, 0xD1, 0x30, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x30, 0, 0, 0);
     for (i = 0; i < textLen; i++)
     {
         device->request[8 + i] = text[i];
@@ -176,7 +177,7 @@ int32_t PK_LCDPutChar(sPoKeysDevice* device, uint8_t character)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0x31, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x31, 0, 0, 0);
     device->request[8] = character;
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
@@ -187,7 +188,7 @@ int32_t PK_LCDEntryModeSet(sPoKeysDevice* device, uint8_t cursorMoveDirection, u
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0x50, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x50, 0, 0, 0);
     device->request[8] = cursorMoveDirection;
     device->request[9] = displayShift;
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -199,7 +200,7 @@ int32_t PK_LCDDisplayOnOffControl(sPoKeysDevice* device, uint8_t displayOnOff, u
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 	if (device->info.iLCD == 0) return PK_ERR_NOT_SUPPORTED;
 
-    CreateRequest(device->request, 0xD1, 0x60, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_LCD_OPERATION, 0x60, 0, 0, 0);
     device->request[8] = displayOnOff;
     device->request[9] = cursorOnOff;
     device->request[10] = cursorBlinking;

--- a/PoKeysLibPoNET.c
+++ b/PoKeysLibPoNET.c
@@ -21,12 +21,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_PoNETGetPoNETStatus(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x00, 0, 0, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_GET_STATUS, 0, 0, 0);
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
   device->PoNETmodule.PoNETstatus = device->response[8];
@@ -38,7 +39,7 @@ int32_t PK_PoNETGetModuleSettings(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x10, device->PoNETmodule.moduleID, 0, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_GET_MODULE_SETTINGS, device->PoNETmodule.moduleID, 0, 0);
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
   device->PoNETmodule.i2cAddress = device->response[8];
@@ -55,7 +56,7 @@ int32_t PK_PoNETGetModuleStatusRequest(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x50, 0x10, device->PoNETmodule.moduleID, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_GET_MODULE_DATA, 0x10, device->PoNETmodule.moduleID, 0);
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
   
   return PK_OK;
@@ -65,7 +66,7 @@ int32_t PK_PoNETGetModuleStatus(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x50, 0x30, 0, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_GET_MODULE_DATA, 0x30, 0, 0);
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
   if (device->response[3] != 1) return PK_ERR_GENERIC;
@@ -83,7 +84,7 @@ int32_t PK_PoNETSetModuleStatus(sPoKeysDevice* device)
 
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x55, device->PoNETmodule.moduleID, 0, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_SET_MODULE_DATA, device->PoNETmodule.moduleID, 0, 0);
   for (i = 0; i < 16; i++)
   {
     device->request[8 + i] = device->PoNETmodule.statusOut[i];
@@ -99,7 +100,7 @@ int32_t PK_PoNETSetModulePWM(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x70, device->PoNETmodule.moduleID, device->PoNETmodule.PWMduty, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_SET_PWM_VALUE, device->PoNETmodule.moduleID, device->PoNETmodule.PWMduty, 0);
   
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
   return PK_OK;
@@ -109,7 +110,7 @@ int32_t PK_PoNETGetModuleLightRequest(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x60, 0x10, device->PoNETmodule.moduleID, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_GET_LIGHT_SENSOR, 0x10, device->PoNETmodule.moduleID, 0);
   
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
   return PK_OK;
@@ -119,7 +120,7 @@ int32_t PK_PoNETGetModuleLight(sPoKeysDevice* device)
 {
   if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-  CreateRequest(device->request, 0xDD, 0x60, 0x30, device->PoNETmodule.moduleID, 0);
+  CreateRequest(device->request, PK_CMD_POI2C_COMMUNICATION, PONET_OP_GET_LIGHT_SENSOR, 0x30, device->PoNETmodule.moduleID, 0);
   
   if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
   if (device->response[8] != 0) return PK_ERR_GENERIC;

--- a/PoKeysLibPulseEngine_v2.c
+++ b/PoKeysLibPulseEngine_v2.c
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 
 void PK_PEv2_DecodeStatus(sPoKeysDevice * device)
@@ -77,7 +78,7 @@ int32_t PK_PEv2_StatusGet(sPoKeysDevice * device)
     tstB = (0x10 + device->requestID) % 199;
 
     // Send request
-    CreateRequest(device->request, 0x85, 0x00, tstB, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_STATUS, tstB, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     // Check if response is valid
@@ -102,7 +103,7 @@ int32_t PK_PEv2_Status2Get(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Send request
-    CreateRequest(device->request, 0x85, 0x08, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_STATUS2, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
 	device->PEv2.DedicatedLimitNInputs = device->response[8];
@@ -116,7 +117,7 @@ int32_t PK_PEv2_PulseEngineSetup(sPoKeysDevice * device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0x85, 0x01, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SETUP, 0, 0, 0);
 
     // Fill the information
     device->request[8] = device->PEv2.PulseEngineEnabled;
@@ -138,7 +139,7 @@ int32_t PK_PEv2_AdditionalParametersGet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Send request
-    CreateRequest(device->request, 0x85, 0x06, 0, 0, 1);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_CONFIGURE_MISC, 0, 0, 1);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
 	device->PEv2.EmergencyInputPin = device->response[8];    
@@ -152,7 +153,7 @@ int32_t PK_PEv2_AdditionalParametersSet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x06, 1, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_CONFIGURE_MISC, 1, 0, 0);
 	device->request[8] = device->PEv2.EmergencyInputPin;
 
     // Send request
@@ -169,7 +170,7 @@ int32_t PK_PEv2_AxisConfigurationGet(sPoKeysDevice * device)
     if (device->PEv2.param1 >= 8) return PK_ERR_PARAMETER;
 
     // Send request
-    CreateRequest(device->request, 0x85, 0x10, device->PEv2.param1, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_AXIS_CONFIGURATION, device->PEv2.param1, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     // Pointer to PEv2 structure for better code readability
@@ -223,7 +224,7 @@ int32_t PK_PEv2_AxisConfigurationSet(sPoKeysDevice * device)
     if (device->PEv2.param1 >= 8) return PK_ERR_PARAMETER;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x11, device->PEv2.param1, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_AXIS_CONFIGURATION, device->PEv2.param1, 0, 0);
 
     // Pointer to PEv2 structure for better code readability
     pe = &device->PEv2;
@@ -277,7 +278,7 @@ int32_t PK_PEv2_PositionSet(sPoKeysDevice * device)
     if (device->PEv2.param2 == 0) return PK_ERR_PARAMETER;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x03, device->PEv2.param2, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_AXIS_POSITION, device->PEv2.param2, 0, 0);
 
     for (i = 0; i < 8; i++)
     {
@@ -294,7 +295,7 @@ int32_t PK_PEv2_PulseEngineStateSet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-	CreateRequest(device->request, 0x85, 0x02, device->PEv2.PulseEngineStateSetup, device->PEv2.LimitOverrideSetup, device->PEv2.AxisEnabledMask);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_STATE, device->PEv2.PulseEngineStateSetup, device->PEv2.LimitOverrideSetup, device->PEv2.AxisEnabledMask);
 
     // Send request
     return SendRequest(device);
@@ -306,7 +307,7 @@ int32_t PK_PEv2_PulseEngineMove(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x20, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_MOVE, 0, 0, 0);
 
     //memcpy(&device->request[8], device->PEv2.ReferencePositionSpeed, 8*4);
     for (int i = 0; i < 8; i++) {
@@ -331,7 +332,7 @@ int32_t PK_PEv2_PulseEngineMovePV(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x25, device->PEv2.param2, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_MOVE_PV, device->PEv2.param2, 0, 0);
 
     //memcpy(&device->request[8], device->PEv2.ReferencePositionSpeed, 8*4);
     for (int i = 0; i < 8; i++) {
@@ -357,7 +358,7 @@ int32_t PK_PEv2_ExternalOutputsGet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Send request
-    CreateRequest(device->request, 0x85, 0x04, 0, 0, 1);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_OUTPUTS, 0, 0, 1);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     device->PEv2.ExternalRelayOutputs = device->response[3];
@@ -372,7 +373,7 @@ int32_t PK_PEv2_ExternalOutputsSet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x04, device->PEv2.ExternalRelayOutputs, device->PEv2.ExternalOCOutputs, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_OUTPUTS, device->PEv2.ExternalRelayOutputs, device->PEv2.ExternalOCOutputs, 0);
     // Send request
     return SendRequest(device);
 }
@@ -385,7 +386,7 @@ int32_t PK_PEv2_BufferFill(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0xFF, device->PEv2.newMotionBufferEntries, device->PEv2.PulseEngineEnabled & 0x0F, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_FILL_BUFFER_8BIT, device->PEv2.newMotionBufferEntries, device->PEv2.PulseEngineEnabled & 0x0F, 0);
 
     // Copy buffer
     memcpy(&device->request[8], device->PEv2.MotionBuffer, 56);
@@ -409,7 +410,7 @@ int32_t PK_PEv2_BufferFill_16(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0xFE, device->PEv2.newMotionBufferEntries, device->PEv2.PulseEngineEnabled & 0x0F, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, 0xFE, device->PEv2.newMotionBufferEntries, device->PEv2.PulseEngineEnabled & 0x0F, 0);
 
     // Copy buffer
     memcpy(&device->request[8], device->PEv2.MotionBuffer, 56);
@@ -473,7 +474,7 @@ int32_t PK_PEv2_BufferClear(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0xF0, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_CLEAR_BUFFER, 0, 0, 0);
     // Send request
     return SendRequest(device);
 }
@@ -484,7 +485,7 @@ int32_t PK_PEv2_PulseEngineReboot(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x05, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_REBOOT, 0, 0, 0);
     // Send request
     return SendRequest(device);
 }
@@ -496,7 +497,7 @@ int32_t PK_PEv2_HomingStart(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x21, device->PEv2.HomingStartMaskSetup, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_START_HOMING, device->PEv2.HomingStartMaskSetup, 0, 0);
 
     //memcpy(&device->request[8], device->PEv2.HomeOffsets, 8 * 4);
     for (int i = 0; i < 8; i++) {
@@ -516,7 +517,7 @@ int32_t PK_PEv2_HomingFinish(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-	CreateRequest(device->request, 0x85, 0x22, device->PEv2.PulseEngineStateSetup, 1, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_FINISH_HOMING, device->PEv2.PulseEngineStateSetup, 1, 0);
     // Send request
     return SendRequest(device);
 }
@@ -531,7 +532,7 @@ int32_t PK_PEv2_ProbingStart(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x23, device->PEv2.ProbeStartMaskSetup, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_START_PROBING, device->PEv2.ProbeStartMaskSetup, 0, 0);
 
     //memcpy(&device->request[8], device->PEv2.ProbeMaxPosition, 8 * 4);
     for (int i = 0; i < 8; i++) {
@@ -555,7 +556,7 @@ int32_t PK_PEv2_ProbingHybridStart(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x23, 0, 1, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_START_PROBING, 0, 1, 0);
 
     device->request[44] = device->PEv2.ProbeInput;
     device->request[45] = device->PEv2.ProbeInputPolarity;
@@ -570,7 +571,7 @@ int32_t PK_PEv2_ProbingFinish(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x24, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_FINISH_PROBING, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -595,7 +596,7 @@ int32_t PK_PEv2_ProbingFinishSimple(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x24, 1, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_FINISH_PROBING, 1, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -617,7 +618,7 @@ int32_t PK_PEv2_ThreadingPrepareForTrigger(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x30, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_PREPARE_TRIGGER, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -630,7 +631,7 @@ int32_t PK_PEv2_ThreadingForceTriggerReady(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x31, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_FORCE_TRIGGER_READY, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -643,7 +644,7 @@ int32_t PK_PEv2_ThreadingTrigger(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x32, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_ARM_TRIGGER, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -656,7 +657,7 @@ int32_t PK_PEv2_ThreadingRelease(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x33, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_RELEASE_TRIGGER, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -669,7 +670,7 @@ int32_t PK_PEv2_ThreadingCancel(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x34, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_CANCEL_THREADING, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -682,7 +683,7 @@ int32_t PK_PEv2_ThreadingStatusGet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x35, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_THREADING_STATUS, 0, 0, 0);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -715,7 +716,7 @@ int32_t PK_PEv2_ThreadingSetup(sPoKeysDevice * device, uint8_t sensorMode, uint1
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x36, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_THREADING_PARAMS, 0, 0, 0);
 
 	device->request[8] = sensorMode;
 	*(uint16_t*)(device->request + 12) = ticksPerRevolution;
@@ -736,7 +737,7 @@ int32_t PK_PEv2_BacklashCompensationSettings_Get(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x40, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_BACKLASH_SETTINGS, 0, 0, 0);
 
 	// Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -759,7 +760,7 @@ int32_t PK_PEv2_BacklashCompensationSettings_Set(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
 	// Create request
-	CreateRequest(device->request, 0x85, 0x41, device->PEv2.BacklashCompensationEnabled, device->PEv2.BacklashCompensationMaxSpeed, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_BACKLASH_SETTINGS, device->PEv2.BacklashCompensationEnabled, device->PEv2.BacklashCompensationMaxSpeed, 0);
 
 	for (i = 0; i < 8; i++)
 	{
@@ -779,7 +780,7 @@ int32_t PK_PEv2_SyncedPWMSetup(sPoKeysDevice * device, uint8_t enabled, uint8_t 
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x0A, enabled, srcAxis, dstPWMChannel);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SETUP_SYNCED_PWM, enabled, srcAxis, dstPWMChannel);
 
     // Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -792,7 +793,7 @@ int32_t PK_PEv2_SyncOutputsSetup(sPoKeysDevice * device)
 	if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
 	// Create request
-	CreateRequest(device->request, 0x85, 0x0B, device->PEv2.SyncFastOutputsAxisID > 0, device->PEv2.SyncFastOutputsAxisID - 1, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SETUP_SYNCED_DIGITAL, device->PEv2.SyncFastOutputsAxisID > 0, device->PEv2.SyncFastOutputsAxisID - 1, 0);
 	memcpy(device->request + 8, device->PEv2.SyncFastOutputsMapping, 8);
 
 	// Send request
@@ -807,7 +808,7 @@ int32_t PK_PoStep_ConfigurationGet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x50, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SETUP_DRIVER_COMM, 0, 0, 0);
 
 	// Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -830,7 +831,7 @@ int32_t PK_PoStep_ConfigurationSet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
 	// Create request
-	CreateRequest(device->request, 0x85, 0x50, 0x10, device->PoSteps.EnablePoStepCommunication, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SETUP_DRIVER_COMM, 0x10, device->PoSteps.EnablePoStepCommunication, 0);
 
 	// Insert settings for each axis
 	for (i = 0; i < 8; i++)
@@ -862,7 +863,7 @@ int32_t PK_PoStep_StatusGet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x51, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_DRIVER_STATUS, 0, 0, 0);
 
 	// Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -889,7 +890,7 @@ int32_t PK_PoStep_DriverConfigurationGet(sPoKeysDevice * device)
 
 	// Current settings
     // Create request
-    CreateRequest(device->request, 0x85, 0x52, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_DRIVER_CURRENT_PARAMS, 0, 0, 0);
 
 	// Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -904,7 +905,7 @@ int32_t PK_PoStep_DriverConfigurationGet(sPoKeysDevice * device)
 
 	// Mode settings
     // Create request
-    CreateRequest(device->request, 0x85, 0x53, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_DRIVER_MODE_PARAMS, 0, 0, 0);
 
 	// Send request
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -928,7 +929,7 @@ int32_t PK_PoStep_DriverConfigurationSet(sPoKeysDevice * device)
 
 	// Current
 	// Create request
-	CreateRequest(device->request, 0x85, 0x52, 0x10, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_DRIVER_CURRENT_PARAMS, 0x10, 0, 0);
 
 	// Insert settings for each axis
 	for (i = 0; i < 8; i++)
@@ -951,7 +952,7 @@ int32_t PK_PoStep_DriverConfigurationSet(sPoKeysDevice * device)
 
 	// Modes
 	// Create request
-	CreateRequest(device->request, 0x85, 0x53, 0x10, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_DRIVER_MODE_PARAMS, 0x10, 0, 0);
 
 	// Insert settings for each axis
 	for (i = 0; i < 8; i++)
@@ -985,7 +986,7 @@ int32_t PK_PEv2_InternalDriversConfigurationGet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Send request
-    CreateRequest(device->request, 0x85, 0x18, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_GET_INTERNAL_DRIVERS, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     // Pointer to PEv2 structure for better code readability
@@ -1005,7 +1006,7 @@ int32_t PK_PEv2_InternalDriversConfigurationSet(sPoKeysDevice * device)
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Create request
-    CreateRequest(device->request, 0x85, 0x19, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_PULSE_ENGINE_V2, PEV2_CMD_SET_INTERNAL_DRIVERS, 0, 0, 0);
 
     // Pointer to PEv2 structure for better code readability
     pe = &device->PEv2;

--- a/PoKeysLibRTC.c
+++ b/PoKeysLibRTC.c
@@ -20,12 +20,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_RTCGet(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0x83, 0x00, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_RTC_SETTINGS, 0x00, 0, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *device->RTC.SEC = device->response[8];
@@ -47,7 +48,7 @@ int32_t PK_RTCSet(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0x83, 0x10, 0, 0, 0);
+    CreateRequest(device->request, PK_CMD_RTC_SETTINGS, 0x10, 0, 0, 0);
     device->request[8]  = (uint8_t)(*device->RTC.SEC);
     device->request[9]  = (uint8_t)(*device->RTC.MIN);
     device->request[10] = (uint8_t)(*device->RTC.HOUR);

--- a/PoKeysLibRTCAsync.c
+++ b/PoKeysLibRTCAsync.c
@@ -134,7 +134,7 @@
      uint8_t params[1] = { 0x00 }; // Only param1 used
  
      // Important: Target is NOT device->RTC directly, but temporary response buffer
-     uint8_t req_id = CreateRequestAsync(device, 0x83, params, 1,
+    uint8_t req_id = CreateRequestAsync(device, PK_CMD_RTC_SETTINGS, params, 1,
                                         NULL, 0,
                                 PK_RTCGetAsync_Process); // Set parser function!
     rtapi_print_msg(RTAPI_MSG_ERR, "PoKeys: %s:%s: PK_RTCGetAsync: req_id=%d\n", __FILE__, __FUNCTION__, req_id);

--- a/PoKeysLibSPI.c
+++ b/PoKeysLibSPI.c
@@ -20,13 +20,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_SPIConfigure(sPoKeysDevice * device, uint8_t prescaler, uint8_t frameFormat)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure SPI
-    CreateRequest(device->request, 0xE5, 0x01, prescaler, frameFormat, 0);
+    CreateRequest(device->request, PK_CMD_SPI_COMMUNICATION, 0x01, prescaler, frameFormat, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }
@@ -38,7 +39,7 @@ int32_t PK_SPIWrite(sPoKeysDevice * device, uint8_t * buffer, uint8_t iDataLengt
 
     if (iDataLength > 55) iDataLength = 55;
 
-    CreateRequest(device->request, 0xE5, 0x10, iDataLength, pinCS, 0);
+    CreateRequest(device->request, PK_CMD_SPI_COMMUNICATION, 0x10, iDataLength, pinCS, 0);
     for (i = 0; i < iDataLength; i++)
     {
         device->request[8+i] = buffer[i];
@@ -55,7 +56,7 @@ int32_t PK_SPIRead(sPoKeysDevice * device, uint8_t * buffer, uint8_t iDataLength
 
     if (iDataLength > 55) iDataLength = 55;
 
-    CreateRequest(device->request, 0xE5, 0x20, iDataLength, 0, 0);
+    CreateRequest(device->request, PK_CMD_SPI_COMMUNICATION, 0x20, iDataLength, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     if (device->response[3] == 1)

--- a/PoKeysLibUART.c
+++ b/PoKeysLibUART.c
@@ -19,13 +19,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_UARTConfigure(sPoKeysDevice* device, uint32_t baudrate, uint8_t format, uint8_t interfaceID)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure UART
-    CreateRequest(device->request, 0xDE, 0x10, interfaceID, format & 0x7F, 0);
+    CreateRequest(device->request, PK_CMD_UART_COMMUNICATION, 0x10, interfaceID, format & 0x7F, 0);
     *(uint32_t*)(device->request + 8) = baudrate;
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
@@ -47,7 +48,7 @@ int32_t PK_UARTWrite(sPoKeysDevice* device, uint8_t interfaceID, uint8_t *dataPt
     {
         if (len > 55) len = 55;
 
-        CreateRequest(device->request, 0xDE, 0x20, interfaceID, len, 0);
+        CreateRequest(device->request, PK_CMD_UART_COMMUNICATION, 0x20, interfaceID, len, 0);
 
         memcpy(device->request + 8, dataPtr + writePtr, len);
         if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
@@ -74,7 +75,7 @@ int32_t PK_UARTRead(sPoKeysDevice* device, uint8_t interfaceID, uint8_t *dataPtr
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
-    CreateRequest(device->request, 0xDE, 0x30, interfaceID, 0, 0);
+    CreateRequest(device->request, PK_CMD_UART_COMMUNICATION, 0x30, interfaceID, 0, 0);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
 
     *dataReadLen = device->response[3];

--- a/PoKeysLibWS2812.c
+++ b/PoKeysLibWS2812.c
@@ -19,13 +19,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "PoKeysLibHal.h"
 #include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
 
 int32_t PK_WS2812_Update(sPoKeysDevice* device, uint16_t LEDcount, uint8_t updateFlag)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
 
     // Configure WS2812 driver
-    CreateRequest(device->request, 0x4B, 0x00, LEDcount & 0xFF, LEDcount >> 8, updateFlag);    
+    CreateRequest(device->request, PK_CMD_WS2812_CONTROL, 0x00, LEDcount & 0xFF, LEDcount >> 8, updateFlag);
     if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }
@@ -37,7 +38,7 @@ int32_t PK_WS2812_SendLEDdataEx(sPoKeysDevice* device, uint32_t * LEDdata, uint1
     if (LEDcount > 18) return PK_ERR_PARAMETER;
 
     // Pack LED data
-    CreateRequest(device->request, 0x4B, 0x10, startLED & 0xFF, startLED >> 8, LEDcount);
+    CreateRequest(device->request, PK_CMD_WS2812_CONTROL, 0x10, startLED & 0xFF, startLED >> 8, LEDcount);
     for (i = 0; i < LEDcount; i++)
     {
         memcpy(device->request + 8 + i*3, &LEDdata[i+LEDoffset], 3);


### PR DESCRIPTION
## Summary
- use enumeration constants when creating requests
- include `PoKeysLibAsync.h` for enum definitions
- keep subcommands numeric when enums are unavailable

## Testing
- `make -f Makefile.noqmake`

------
https://chatgpt.com/codex/tasks/task_e_684c8510fcdc832285a6ccebd41ffc66