### PR TITLE
Fix WS2812 checksum handling

### DIFF
--- a/PoKeysLibWS2812.c
+++ b/PoKeysLibWS2812.c
@@ -44,6 +44,13 @@ int32_t PK_WS2812_SendLEDdataEx(sPoKeysDevice* device, uint32_t * LEDdata, uint1
         memcpy(device->request + 8 + i*3, &LEDdata[i+LEDoffset], 3);
     }
 
+    // Second checksum covers LED data only (bytes 8-62)
+    device->request[63] = 0;
+    for (i = 8; i < 63; i++)
+    {
+        device->request[63] += device->request[i];
+    }
+    // SendRequest_NoResponse will append packet header and first checksum (bytes 0-6)
     if (SendRequest_NoResponse(device) != PK_OK) return PK_ERR_TRANSFER;
     return PK_OK;
 }


### PR DESCRIPTION
## Summary
- compute second WS2812 checksum before sending LED data
- document both checksums

## Testing
- `make -f Makefile.noqmake`

------
https://chatgpt.com/codex/tasks/task_e_684e7ee6b2d483229e74074f9f06878c