### PR TITLE
Add security command support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(PoKeys SHARED
             PoKeysLibPulseEngine_v2.c
             PoKeysLibCAN.c
             PoKeysLibCANAsync.c
+            PoKeysLibSecurity.c
+            PoKeysLibSecurityAsync.c
             PoKeysLibUART.c
             PoKeysLibWS2812.c)
 

--- a/Makefile.noqmake
+++ b/Makefile.noqmake
@@ -12,6 +12,8 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-libusb.c PoKeysLibFastUSB.c \
         PoKeysLibUART.c \
         PoKeysLibCAN.c \
         PoKeysLibCANAsync.c \
+        PoKeysLibSecurity.c \
+        PoKeysLibSecurityAsync.c \
         PoKeysLibFailsafe.c \
         PoKeysLibI2CAsync.c \
         PoKeysLibWS2812.c \

--- a/Makefile.noqmake.osx
+++ b/Makefile.noqmake.osx
@@ -13,6 +13,8 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-mac.c PoKeysLibFastUSB.c \
         PoKeysLibUART.c \
         PoKeysLibCAN.c \
         PoKeysLibCANAsync.c \
+        PoKeysLibSecurity.c \
+        PoKeysLibSecurityAsync.c \
         PoKeysLibFailsafe.c \
         PoKeysLibWS2812.c        
 

--- a/Makefile.noqmakeRT
+++ b/Makefile.noqmakeRT
@@ -12,6 +12,8 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c PoKeysLibFastUSB.c \
         PoKeysLibUART.c \
         PoKeysLibCAN.c \
         PoKeysLibCANAsync.c \
+        PoKeysLibSecurity.c \
+        PoKeysLibSecurityAsync.c \
         PoKeysLibFailsafe.c \
         PoKeysLibWS2812.c \
         PoKeysLibEncodersAsync.c \

--- a/PoKeysLib.h
+++ b/PoKeysLib.h
@@ -1288,6 +1288,14 @@ int PK_CANWriteAsync(sPoKeysDevice* device, sPoKeysCANmsg * msg);
 int PK_CANReadAsync(sPoKeysDevice* device, sPoKeysCANmsg * msg, uint8_t * status);
 int PK_CANFlushAsync(sPoKeysDevice* device);
 
+// Security commands
+POKEYSDECL int32_t PK_SecurityStatusGet(sPoKeysDevice* device, uint8_t* level, uint8_t* seed32);
+POKEYSDECL int32_t PK_UserAuthorise(sPoKeysDevice* device, uint8_t level, const uint8_t* hash20, uint8_t* status);
+POKEYSDECL int32_t PK_UserPasswordSet(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password32);
+int PK_SecurityStatusGetAsync(sPoKeysDevice* device, uint8_t* level, uint8_t* seed32);
+int PK_UserAuthoriseAsync(sPoKeysDevice* device, uint8_t level, const uint8_t* hash20, uint8_t* status);
+int PK_UserPasswordSetAsync(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password32);
+
 // WS2812 commands
 POKEYSDECL int32_t PK_WS2812_Update(sPoKeysDevice* device, uint16_t LEDcount, uint8_t updateFlag);
 POKEYSDECL int32_t PK_WS2812_SendLEDdata(sPoKeysDevice* device, uint32_t * LEDdata, uint16_t startLED, uint8_t LEDcount);

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -1390,6 +1390,14 @@ int PK_CANWriteAsync(sPoKeysDevice* device, sPoKeysCANmsg * msg);
 int PK_CANReadAsync(sPoKeysDevice* device, sPoKeysCANmsg * msg, uint8_t * status);
 int PK_CANFlushAsync(sPoKeysDevice* device);
 
+// Security commands
+POKEYSDECL int32_t PK_SecurityStatusGet(sPoKeysDevice* device, uint8_t* level, uint8_t* seed32);
+POKEYSDECL int32_t PK_UserAuthorise(sPoKeysDevice* device, uint8_t level, const uint8_t* hash20, uint8_t* status);
+POKEYSDECL int32_t PK_UserPasswordSet(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password32);
+int PK_SecurityStatusGetAsync(sPoKeysDevice* device, uint8_t* level, uint8_t* seed32);
+int PK_UserAuthoriseAsync(sPoKeysDevice* device, uint8_t level, const uint8_t* hash20, uint8_t* status);
+int PK_UserPasswordSetAsync(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password32);
+
 // WS2812 commands
 POKEYSDECL int32_t PK_WS2812_Update(sPoKeysDevice* device, uint16_t LEDcount, uint8_t updateFlag);
 POKEYSDECL int32_t PK_WS2812_SendLEDdata(sPoKeysDevice* device, uint32_t * LEDdata, uint16_t startLED, uint8_t LEDcount);

--- a/PoKeysLibSecurity.c
+++ b/PoKeysLibSecurity.c
@@ -1,0 +1,39 @@
+#include "PoKeysLibHal.h"
+#include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+int32_t PK_SecurityStatusGet(sPoKeysDevice* device, uint8_t* level, uint8_t* seed)
+{
+    if (device == NULL) return PK_ERR_NOT_CONNECTED;
+
+    CreateRequest(device->request, PK_CMD_SECURITY_STATUS_GET, 0, 0, 0, 0);
+    if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+
+    if (level) *level = device->response[8];
+    if (seed) memcpy(seed, device->response + 9, 32);
+    return PK_OK;
+}
+
+int32_t PK_UserAuthorise(sPoKeysDevice* device, uint8_t level, const uint8_t* hash, uint8_t* status)
+{
+    if (device == NULL) return PK_ERR_NOT_CONNECTED;
+
+    CreateRequest(device->request, PK_CMD_USER_AUTHORISE, level, 0, 0, 0);
+    memcpy(device->request + 8, hash, 20);
+    if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+
+    if (status) *status = device->response[8];
+    return PK_OK;
+}
+
+int32_t PK_UserPasswordSet(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password)
+{
+    if (device == NULL) return PK_ERR_NOT_CONNECTED;
+
+    CreateRequest(device->request, PK_CMD_USER_PASSWORD_SET, defaultLevel, 0, 0, 0);
+    memcpy(device->request + 8, password, 32);
+    if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+
+    return PK_OK;
+}

--- a/PoKeysLibSecurityAsync.c
+++ b/PoKeysLibSecurityAsync.c
@@ -1,0 +1,65 @@
+#include "PoKeysLibHal.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+typedef struct {
+    uint8_t *level_ptr;
+    uint8_t *seed_ptr;
+    uint8_t *status_ptr;
+    uint8_t used;
+} SecurityAsyncContext;
+
+static SecurityAsyncContext sec_ctx[256];
+
+static int PK_SecurityStatus_Parse(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    uint8_t id = resp[6];
+    SecurityAsyncContext *c = &sec_ctx[id];
+    if (c->level_ptr)
+        *(c->level_ptr) = resp[8];
+    if (c->seed_ptr)
+        memcpy(c->seed_ptr, resp + 9, 32);
+    c->used = 0;
+    return PK_OK;
+}
+
+static int PK_UserAuthorise_Parse(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    uint8_t id = resp[6];
+    SecurityAsyncContext *c = &sec_ctx[id];
+    if (c->status_ptr)
+        *(c->status_ptr) = resp[8];
+    c->used = 0;
+    return PK_OK;
+}
+
+int PK_SecurityStatusGetAsync(sPoKeysDevice* device, uint8_t* level, uint8_t* seed)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    int req = CreateRequestAsync(device, PK_CMD_SECURITY_STATUS_GET, NULL, 0, NULL, 0, PK_SecurityStatus_Parse);
+    if (req < 0) return req;
+    sec_ctx[req].level_ptr = level;
+    sec_ctx[req].seed_ptr = seed;
+    sec_ctx[req].used = 1;
+    return SendRequestAsync(device, req);
+}
+
+int PK_UserAuthoriseAsync(sPoKeysDevice* device, uint8_t level, const uint8_t* hash, uint8_t* status)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    uint8_t params[1] = { level };
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_USER_AUTHORISE, params, 1, hash, 20, PK_UserAuthorise_Parse);
+    if (req < 0) return req;
+    sec_ctx[req].status_ptr = status;
+    sec_ctx[req].used = 1;
+    return SendRequestAsync(device, req);
+}
+
+int PK_UserPasswordSetAsync(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    uint8_t params[1] = { defaultLevel };
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_USER_PASSWORD_SET, params, 1, password, 32, NULL);
+    if (req < 0) return req;
+    return SendRequestAsync(device, req);
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ This project provides an optimized PoKeysLib UDP/Ethernet communication layer fo
 - Fast, safe, and predictable response handling
 - Clear separation of send and receive flow
 
+## Security Commands
+
+The library now supports PoKeys security management:
+
+- **PK_SecurityStatusGet** (command `0xE1`)
+  - Request: no parameters.
+  - Response: byte 9 contains the current security level, bytes 10–41 contain a 32-byte seed used when hashing the password.
+- **PK_UserAuthorise** (command `0xE2`)
+  - Request: param1 is desired security level; payload is 20-byte SHA‑1 password hash.
+  - Response: byte 9 is the unlock status (`0xAA` if successful).
+- **PK_UserPasswordSet** (command `0xE3`)
+  - Request: param1 is default security level; payload is the password in plain text (32 bytes).
+  - Response: header only (no additional data).
+
 ## Flowchart
 
 ```plaintext


### PR DESCRIPTION
## Summary
- implement security commands in new PoKeysLibSecurity modules
- provide async wrappers using CreateRequestAsync
- export new APIs in public headers
- document security protocol in README
- add sources to build scripts

## Testing
- `make -f Makefile.noqmake`
- `make -f Makefile.noqmakeRT` *(fails: No rule to make target 'hal_digital.c')*
- `cmake -S . -B build`
- `cmake --build build` *(fails: hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684e83286c648322a9ec5af77f49146b