### PR TITLE
Add COSM settings API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(PoKeys SHARED
             PoKeysLibCANAsync.c
             PoKeysLibSecurity.c
             PoKeysLibSecurityAsync.c
+            PoKeysLibCOSM.c
+            PoKeysLibCOSMAsync.c
             PoKeysLibUART.c
             PoKeysLibWS2812.c)
 

--- a/Makefile.noqmake
+++ b/Makefile.noqmake
@@ -14,6 +14,8 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-libusb.c PoKeysLibFastUSB.c \
         PoKeysLibCANAsync.c \
         PoKeysLibSecurity.c \
         PoKeysLibSecurityAsync.c \
+        PoKeysLibCOSM.c \
+        PoKeysLibCOSMAsync.c \
         PoKeysLibFailsafe.c \
         PoKeysLibI2CAsync.c \
         PoKeysLibWS2812.c \

--- a/Makefile.noqmake.osx
+++ b/Makefile.noqmake.osx
@@ -15,8 +15,10 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-mac.c PoKeysLibFastUSB.c \
         PoKeysLibCANAsync.c \
         PoKeysLibSecurity.c \
         PoKeysLibSecurityAsync.c \
+        PoKeysLibCOSM.c \
+        PoKeysLibCOSMAsync.c \
         PoKeysLibFailsafe.c \
-        PoKeysLibWS2812.c        
+        PoKeysLibWS2812.c
 
 OBJECTS=$(SOURCES:.c=.o)
 

--- a/Makefile.noqmakeRT
+++ b/Makefile.noqmakeRT
@@ -14,6 +14,8 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c PoKeysLibFastUSB.c \
         PoKeysLibCANAsync.c \
         PoKeysLibSecurity.c \
         PoKeysLibSecurityAsync.c \
+        PoKeysLibCOSM.c \
+        PoKeysLibCOSMAsync.c \
         PoKeysLibFailsafe.c \
         PoKeysLibWS2812.c \
         PoKeysLibEncodersAsync.c \

--- a/PoKeysLib.h
+++ b/PoKeysLib.h
@@ -861,6 +861,18 @@ typedef struct
     uint32_t AnalogRCFilter;
 } sPoKeysOtherPeripherals;
 
+// COSM/HTTP reporting settings
+typedef struct
+{
+    uint16_t updateRate;                            // Report update rate
+    uint8_t  serverIP[4];                           // Server IP address
+    uint16_t serverPort;                            // Server port number
+    uint8_t  requestType;                           // Request type / protocol bits
+    uint16_t lastStatusCode;                        // Last HTTP status code
+    uint8_t  protocolDescription[46];               // Protocol description bytes
+    uint8_t  requestHeaders[5][50];                 // HTTP header in 5 pages
+} sPoKeysCOSMSettings;
+
 
 // Failsafe settings
 typedef struct
@@ -913,6 +925,7 @@ typedef struct
 
     sPoKeysOtherPeripherals   otherPeripherals;
     sPoKeysFailsafeSettings   failsafeSettings;
+    sPoKeysCOSMSettings       COSM;
     ALIGN_TEST(3)
 
     uint8_t                   FastEncodersConfiguration;     // Fast encoders configuration, invert settings and 4x sampling (see protocol specification for details)
@@ -1295,6 +1308,12 @@ POKEYSDECL int32_t PK_UserPasswordSet(sPoKeysDevice* device, uint8_t defaultLeve
 int PK_SecurityStatusGetAsync(sPoKeysDevice* device, uint8_t* level, uint8_t* seed32);
 int PK_UserAuthoriseAsync(sPoKeysDevice* device, uint8_t level, const uint8_t* hash20, uint8_t* status);
 int PK_UserPasswordSetAsync(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password32);
+
+// COSM / HTTP reporting
+POKEYSDECL int32_t PK_COSMSettingsGet(sPoKeysDevice* device);
+POKEYSDECL int32_t PK_COSMSettingsSet(sPoKeysDevice* device);
+int PK_COSMSettingsGetAsync(sPoKeysDevice* device, sPoKeysCOSMSettings* settings);
+int PK_COSMSettingsSetAsync(sPoKeysDevice* device, const sPoKeysCOSMSettings* settings);
 
 // WS2812 commands
 POKEYSDECL int32_t PK_WS2812_Update(sPoKeysDevice* device, uint16_t LEDcount, uint8_t updateFlag);

--- a/PoKeysLibCOSM.c
+++ b/PoKeysLibCOSM.c
@@ -1,0 +1,55 @@
+#include "PoKeysLibHal.h"
+#include "PoKeysLibCore.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+int32_t PK_COSMSettingsGet(sPoKeysDevice* device)
+{
+    if (device == NULL) return PK_ERR_NOT_CONNECTED;
+
+    // Request operation 0 - read basic settings
+    CreateRequest(device->request, PK_CMD_COSM_SETTINGS, 0, 0, 0, 0);
+    if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+
+    device->COSM.updateRate = device->response[9] | (device->response[10] << 8);
+    memcpy(device->COSM.serverIP, device->response + 11, 4);
+    device->COSM.requestType = device->response[15];
+    device->COSM.lastStatusCode = device->response[16] | (device->response[17] << 8);
+    device->COSM.serverPort = device->response[18] | (device->response[19] << 8);
+
+    // Read HTTP headers - operations 1..5
+    for (int page = 0; page < 5; page++)
+    {
+        CreateRequest(device->request, PK_CMD_COSM_SETTINGS, page + 1, 0, 0, 0);
+        if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+        memcpy(device->COSM.requestHeaders[page], device->response + 9, 50);
+    }
+
+    return PK_OK;
+}
+
+int32_t PK_COSMSettingsSet(sPoKeysDevice* device)
+{
+    if (device == NULL) return PK_ERR_NOT_CONNECTED;
+
+    // Operation 10 - set basic settings
+    CreateRequest(device->request, PK_CMD_COSM_SETTINGS, 10, 0, 0, 0);
+    device->request[9]  = device->COSM.updateRate & 0xFF;
+    device->request[10] = (device->COSM.updateRate >> 8) & 0xFF;
+    memcpy(device->request + 11, device->COSM.serverIP, 4);
+    device->request[15] = device->COSM.requestType;
+    device->request[16] = device->COSM.serverPort & 0xFF;
+    device->request[17] = (device->COSM.serverPort >> 8) & 0xFF;
+    memcpy(device->request + 18, device->COSM.protocolDescription, 46);
+    if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+
+    // Send request header pages 0..4 using operations 11..15
+    for (int page = 0; page < 5; page++)
+    {
+        CreateRequest(device->request, PK_CMD_COSM_SETTINGS, 11 + page, 0, 0, 0);
+        memcpy(device->request + 9, device->COSM.requestHeaders[page], 50);
+        if (SendRequest(device) != PK_OK) return PK_ERR_TRANSFER;
+    }
+
+    return PK_OK;
+}

--- a/PoKeysLibCOSMAsync.c
+++ b/PoKeysLibCOSMAsync.c
@@ -1,0 +1,94 @@
+#include "PoKeysLibHal.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+typedef struct {
+    sPoKeysCOSMSettings *settings;
+    uint8_t page;
+    uint8_t used;
+} COSMAsyncContext;
+
+static COSMAsyncContext cosm_ctx[256];
+
+static int PK_COSM_ParseBasic(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    uint8_t id = resp[6];
+    COSMAsyncContext *c = &cosm_ctx[id];
+    sPoKeysCOSMSettings *s = c->settings;
+    if (s) {
+        s->updateRate = resp[9] | (resp[10] << 8);
+        memcpy(s->serverIP, resp + 11, 4);
+        s->requestType = resp[15];
+        s->lastStatusCode = resp[16] | (resp[17] << 8);
+        s->serverPort = resp[18] | (resp[19] << 8);
+    }
+    c->used = 0;
+    return PK_OK;
+}
+
+static int PK_COSM_ParseHeader(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    uint8_t id = resp[6];
+    COSMAsyncContext *c = &cosm_ctx[id];
+    if (c->settings) {
+        memcpy(c->settings->requestHeaders[c->page], resp + 9, 50);
+    }
+    c->used = 0;
+    return PK_OK;
+}
+
+int PK_COSMSettingsGetAsync(sPoKeysDevice* device, sPoKeysCOSMSettings* settings)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    uint8_t param0[1] = { 0 };
+    int req = CreateRequestAsync(device, PK_CMD_COSM_SETTINGS, param0, 1, NULL, 0, PK_COSM_ParseBasic);
+    if (req < 0) return req;
+    cosm_ctx[req].settings = settings;
+    cosm_ctx[req].used = 1;
+    int err = SendRequestAsync(device, req);
+    if (err != PK_OK) return err;
+
+    // Queue additional requests for headers
+    for (int p=0; p<5; p++) {
+        uint8_t param[1] = { (uint8_t)(p+1) };
+        int r = CreateRequestAsync(device, PK_CMD_COSM_SETTINGS, param, 1, NULL, 0, PK_COSM_ParseHeader);
+        if (r < 0) return r;
+        cosm_ctx[r].settings = settings;
+        cosm_ctx[r].page = p;
+        cosm_ctx[r].used = 1;
+        err = SendRequestAsync(device, r);
+        if (err != PK_OK) return err;
+    }
+    return PK_OK;
+}
+
+int PK_COSMSettingsSetAsync(sPoKeysDevice* device, const sPoKeysCOSMSettings* settings)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    uint8_t param10[1] = { 10 };
+    uint8_t tmp[64] = {0};
+    tmp[1] = 0; // not used, but ensure zero
+    tmp[0] = 0; // not used
+    // Build payload for operation 10 starting at byte 9
+    tmp[0] = settings->updateRate & 0xFF;
+    tmp[1] = (settings->updateRate >> 8) & 0xFF;
+    memcpy(tmp + 2, settings->serverIP, 4);
+    tmp[6] = settings->requestType;
+    tmp[7] = settings->serverPort & 0xFF;
+    tmp[8] = (settings->serverPort >> 8) & 0xFF;
+    memcpy(tmp + 9, settings->protocolDescription, 46);
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_COSM_SETTINGS, param10, 1, tmp, 55, NULL);
+    if (req < 0) return req;
+    int err = SendRequestAsync(device, req);
+    if (err != PK_OK) return err;
+
+    // send headers
+    for (int p=0; p<5; p++) {
+        uint8_t param[1] = { (uint8_t)(11+p) };
+        req = CreateRequestAsyncWithPayload(device, PK_CMD_COSM_SETTINGS, param, 1, settings->requestHeaders[p], 50, NULL);
+        if (req < 0) return req;
+        err = SendRequestAsync(device, req);
+        if (err != PK_OK) return err;
+    }
+    return PK_OK;
+}

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -899,6 +899,18 @@ typedef struct
  hal_u32_t  AnalogRCFilter;
 } sPoKeysOtherPeripherals;
 
+// COSM/HTTP reporting settings
+typedef struct
+{
+    uint16_t updateRate;
+    uint8_t  serverIP[4];
+    uint16_t serverPort;
+    uint8_t  requestType;
+    uint16_t lastStatusCode;
+    uint8_t  protocolDescription[46];
+    uint8_t  requestHeaders[5][50];
+} sPoKeysCOSMSettings;
+
 
 // Failsafe settings
 typedef struct
@@ -957,6 +969,7 @@ typedef struct
 
  sPoKeysOtherPeripherals   otherPeripherals;
  sPoKeysFailsafeSettings   failsafeSettings;
+ sPoKeysCOSMSettings       COSM;
  ALIGN_TEST(3)
 
  hal_u32_t                   FastEncodersConfiguration;     // Fast encoders configuration, invert settings and 4x sampling (see protocol specification for details)
@@ -1397,6 +1410,12 @@ POKEYSDECL int32_t PK_UserPasswordSet(sPoKeysDevice* device, uint8_t defaultLeve
 int PK_SecurityStatusGetAsync(sPoKeysDevice* device, uint8_t* level, uint8_t* seed32);
 int PK_UserAuthoriseAsync(sPoKeysDevice* device, uint8_t level, const uint8_t* hash20, uint8_t* status);
 int PK_UserPasswordSetAsync(sPoKeysDevice* device, uint8_t defaultLevel, const uint8_t* password32);
+
+// COSM / HTTP reporting
+POKEYSDECL int32_t PK_COSMSettingsGet(sPoKeysDevice* device);
+POKEYSDECL int32_t PK_COSMSettingsSet(sPoKeysDevice* device);
+int PK_COSMSettingsGetAsync(sPoKeysDevice* device, sPoKeysCOSMSettings* settings);
+int PK_COSMSettingsSetAsync(sPoKeysDevice* device, const sPoKeysCOSMSettings* settings);
 
 // WS2812 commands
 POKEYSDECL int32_t PK_WS2812_Update(sPoKeysDevice* device, uint16_t LEDcount, uint8_t updateFlag);


### PR DESCRIPTION
## Summary
- implement COSM settings structure
- add synchronous and async COSM configuration commands
- expose the new API in headers
- compile COSM sources via Makefiles and CMake

## Testing
- `make -f Makefile.noqmake`

------
https://chatgpt.com/codex/tasks/task_e_684e96a4dc048322aff4716646700047