### PR TITLE
Add 1-wire API documentation

### DIFF
--- a/PoKeysLib1Wire.c
+++ b/PoKeysLib1Wire.c
@@ -22,6 +22,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "PoKeysLibCore.h"
 #include "PoKeysLibAsync.h"
 
+/**
+ * @brief Enable or disable the 1-wire bus.
+ *
+ * Issues command 0xDC with operation code 0x01 to enable or
+ * 0x00 to disable the bus as defined in the protocol specification
+ * ("1-wire settings and communication").
+ *
+ * @param device  Pointer to an opened PoKeys device.
+ * @param activated  Non-zero to activate the bus, zero to deactivate.
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED when @p device is NULL or
+ *         an error returned by SendRequest (for example PK_ERR_TRANSFER).
+ */
 int32_t PK_1WireStatusSet(sPoKeysDevice* device, uint8_t activated)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
@@ -30,6 +42,17 @@ int32_t PK_1WireStatusSet(sPoKeysDevice* device, uint8_t activated)
     return SendRequest(device);
 }
 
+/**
+ * @brief Query the 1-wire activation status.
+ *
+ * Sends command 0xDC/0x11 which returns the current activation
+ * state in the response.
+ *
+ * @param device      Pointer to an opened PoKeys device.
+ * @param activated   Destination for the activation flag (1 when enabled).
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED if @p device is NULL or
+ *         PK_ERR_TRANSFER on communication failure.
+ */
 int32_t PK_1WireStatusGet(sPoKeysDevice* device, uint8_t* activated)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
@@ -41,6 +64,19 @@ int32_t PK_1WireStatusGet(sPoKeysDevice* device, uint8_t* activated)
     return PK_OK;
 }
 
+/**
+ * @brief Start a reset/write/read transaction on the 1-wire bus.
+ *
+ * Executes command 0xDC/0x10 ("Start Reset, Write and Read process").
+ * Up to 16 bytes may be written and read in a single transaction.
+ *
+ * @param device     Pointer to an opened PoKeys device.
+ * @param WriteCount Number of bytes to write (clamped to 16).
+ * @param ReadCount  Number of bytes to read (clamped to 16).
+ * @param data       Buffer containing bytes to write.
+ * @return PK_OK when the command is sent successfully, PK_ERR_NOT_CONNECTED
+ *         if @p device is NULL or an error from SendRequest.
+ */
 int32_t PK_1WireWriteReadStart(sPoKeysDevice* device, uint8_t WriteCount, uint8_t ReadCount, uint8_t * data)
 {
     uint32_t i;
@@ -57,6 +93,20 @@ int32_t PK_1WireWriteReadStart(sPoKeysDevice* device, uint8_t WriteCount, uint8_
     return SendRequest(device);
 }
 
+/**
+ * @brief Retrieve data from the previous 1-wire read operation.
+ *
+ * Sends command 0xDC/0x11 to obtain the read status and any
+ * returned bytes.
+ *
+ * @param device      Pointer to an opened PoKeys device.
+ * @param readStatus  Operation status: 1 when data is available.
+ * @param ReadCount   Receives the number of bytes returned.
+ * @param data        Buffer that receives the read bytes (up to 16).
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED if @p device is NULL,
+ *         PK_ERR_TRANSFER on communication failure or PK_ERR_PARAMETER
+ *         if the returned byte count is invalid.
+ */
 int32_t PK_1WireReadStatusGet(sPoKeysDevice* device, uint8_t * readStatus, uint8_t * ReadCount, uint8_t * data)
 {
     uint32_t i;
@@ -86,6 +136,21 @@ int32_t PK_1WireReadStatusGet(sPoKeysDevice* device, uint8_t * readStatus, uint8
 
 
 
+/**
+ * @brief Start a 1-wire transaction on a specific pin.
+ *
+ * Same as PK_1WireWriteReadStart() but allows selecting the
+ * 1-wire pin. Uses command 0xDC/0x10 with the pin ID in the
+ * third parameter byte.
+ *
+ * @param device     Pointer to an opened PoKeys device.
+ * @param pinID      PoKeys pin used for 1-wire communication.
+ * @param WriteCount Number of bytes to write (clamped to 16).
+ * @param ReadCount  Number of bytes to read (clamped to 16).
+ * @param data       Buffer of bytes to send.
+ * @return PK_OK when the command is sent, PK_ERR_NOT_CONNECTED if
+ *         @p device is NULL or an error from SendRequest.
+ */
 int32_t PK_1WireWriteReadStartEx(sPoKeysDevice* device, uint8_t pinID, uint8_t WriteCount, uint8_t ReadCount, uint8_t * data)
 {
     uint32_t i;
@@ -103,6 +168,16 @@ int32_t PK_1WireWriteReadStartEx(sPoKeysDevice* device, uint8_t pinID, uint8_t W
 }
 
 
+/**
+ * @brief Begin scanning the 1-wire bus for devices.
+ *
+ * Issues command 0xDC/0x20 with the selected pin ID.
+ *
+ * @param device  Pointer to an opened PoKeys device.
+ * @param pinID   PoKeys pin used for the scan.
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED if @p device is NULL
+ *         or an error from SendRequest.
+ */
 int32_t PK_1WireBusScanStart(sPoKeysDevice* device, uint8_t pinID)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
@@ -111,6 +186,19 @@ int32_t PK_1WireBusScanStart(sPoKeysDevice* device, uint8_t pinID)
     return SendRequest(device);
 }
 
+/**
+ * @brief Obtain status and results of a 1-wire bus scan.
+ *
+ * Command 0xDC/0x21 returns the current scanning state and the
+ * discovered device ROM code when available.
+ *
+ * @param device          Pointer to an opened PoKeys device.
+ * @param operationStatus Receives operation status byte.
+ * @param scanResult      Receives scan progress flags.
+ * @param deviceROM       Buffer for the 8 byte device ROM.
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED if @p device is NULL or
+ *         PK_ERR_TRANSFER on communication failure.
+ */
 int32_t PK_1WireBusScanGetResults(sPoKeysDevice* device, uint8_t * operationStatus, uint8_t * scanResult, uint8_t * deviceROM)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
@@ -127,6 +215,15 @@ int32_t PK_1WireBusScanGetResults(sPoKeysDevice* device, uint8_t * operationStat
 
 
 
+/**
+ * @brief Continue a previously started 1-wire bus scan.
+ *
+ * Sends command 0xDC/0x22.
+ *
+ * @param device Pointer to an opened PoKeys device.
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED if @p device is NULL
+ *         or an error from SendRequest.
+ */
 int32_t PK_1WireBusScanContinue(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;
@@ -136,6 +233,15 @@ int32_t PK_1WireBusScanContinue(sPoKeysDevice* device)
 }
 
 
+/**
+ * @brief Stop an ongoing 1-wire bus scan.
+ *
+ * Uses command 0xDC/0x23 to terminate the scan procedure.
+ *
+ * @param device Pointer to an opened PoKeys device.
+ * @return PK_OK on success, PK_ERR_NOT_CONNECTED if @p device is NULL
+ *         or an error from SendRequest.
+ */
 int32_t PK_1WireBusScanStop(sPoKeysDevice* device)
 {
     if (device == NULL) return PK_ERR_NOT_CONNECTED;


### PR DESCRIPTION
## Summary
- document 1‑wire helper functions with Doxygen blocks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ead56c88c832281d6e6439afaa686