### PR TITLE
Add documentation for PoKeys57Industrial helpers

### DIFF
--- a/PoKeysLibDevicePoKeys57Industrial.h
+++ b/PoKeysLibDevicePoKeys57Industrial.h
@@ -70,8 +70,11 @@
 #endif
         } sPoKeys57Industrial;
 
+        /** Connect to a PoKeys57Industrial device (network or USB). */
         POKEYSDECL sPoKeys57Industrial* PK57i_Connect(void);
+        /** Disconnect and release the PoKeys57Industrial handle. */
         POKEYSDECL void PK57i_Disconnect(sPoKeys57Industrial * device);
+        /** Exchange I/O states using command 0x3F. */
         POKEYSDECL int32_t PK57i_Update(sPoKeys57Industrial* device, uint8_t resetFaults);
 
     #ifdef __cplusplus


### PR DESCRIPTION
## Summary
- document PK57i_Connect, PK57i_Disconnect, PK57i_Update and PK57i_SearchDevice
- mention protocol discovery packet and full I/O command

## Testing
- `make -f Makefile.noqmake`


------
https://chatgpt.com/codex/tasks/task_e_684ec30d7b708322afe6c32f00ceabb7