### PR TITLE
Add Matrix Keyboard docs

### DIFF
--- a/PoKeysLib.h
+++ b/PoKeysLib.h
@@ -1207,11 +1207,35 @@ POKEYSDECL int32_t PK_AnalogRCFilterGet(sPoKeysDevice* device);
 /** Set RC filter constant for analog inputs. */
 POKEYSDECL int32_t PK_AnalogRCFilterSet(sPoKeysDevice* device);
 
-// Get matrix keyboard configuration
+/**
+ * Read the matrix keyboard configuration and key mapping.
+ *
+ * Fields in ::sMatrixKeyboard within the provided device structure are
+ * populated by issuing subcommands of `PK_CMD_MATRIX_KEYBOARD_CFG`.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_MatrixKBConfigurationGet(sPoKeysDevice* device);
-// Set matrix keyboard configuration
+/**
+ * Write the current matrix keyboard configuration and key mapping.
+ *
+ * Values are taken from the ::sMatrixKeyboard fields of `device` and sent
+ * using subcommands of `PK_CMD_MATRIX_KEYBOARD_CFG`.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_MatrixKBConfigurationSet(sPoKeysDevice* device);
-// Get matrix keyboard current key states
+/**
+ * Retrieve the matrix keyboard key state bitmap.
+ *
+ * Updates ::sMatrixKeyboard::matrixKBvalues with the currently pressed keys
+ * using subcommand `20` of `PK_CMD_MATRIX_KEYBOARD_CFG`.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_MatrixKBStatusGet(sPoKeysDevice* device);
 
 /**

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -1261,11 +1261,24 @@ int PK_PWMUpdateAsync(sPoKeysDevice* device);
 int PK_PoExtBusSetAsync(sPoKeysDevice* device);
 int PK_PoExtBusGetAsync(sPoKeysDevice* device);
 
-// Get matrix keyboard configuration
+/**
+ * Read the matrix keyboard configuration and key mapping.
+ *
+ * Populates ::sMatrixKeyboard fields in the device structure using
+ * `PK_CMD_MATRIX_KEYBOARD_CFG` subcommands.
+ */
 POKEYSDECL int32_t PK_MatrixKBConfigurationGet(sPoKeysDevice* device);
-// Set matrix keyboard configuration
+/**
+ * Write the matrix keyboard configuration held in ::sMatrixKeyboard.
+ *
+ * All configuration data is sent using `PK_CMD_MATRIX_KEYBOARD_CFG`
+ * subcommands.
+ */
 POKEYSDECL int32_t PK_MatrixKBConfigurationSet(sPoKeysDevice* device);
-// Get matrix keyboard current key states
+/**
+ * Refresh the matrix keyboard state bitmap stored in
+ * ::sMatrixKeyboard::matrixKBvalues.
+ */
 POKEYSDECL int32_t PK_MatrixKBStatusGet(sPoKeysDevice* device);
 
 /**

--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ The library now supports PoKeys security management:
 - **PK_RTCSet**
   - Sends the values from `device->RTC` to update the device's internal clock.
 
+## Matrix Keyboard Functions
+
+- **PK_MatrixKBConfigurationGet**
+  - Reads matrix keyboard configuration and key mapping into `device->matrixKB`.
+- **PK_MatrixKBConfigurationSet**
+  - Writes configuration and key mapping from `device->matrixKB` back to the device.
+- **PK_MatrixKBStatusGet**
+  - Updates `device->matrixKB.matrixKBvalues` with the currently pressed keys.
+
 ## Asynchronous IO Wrappers
 
 - **PK_PinConfigurationGetAsync**

--- a/docs/MatrixKeyboard_commands.md
+++ b/docs/MatrixKeyboard_commands.md
@@ -1,0 +1,20 @@
+# Matrix Keyboard Commands
+
+This document summarises the helper functions implemented in **PoKeysLibMatrixKB.c**.
+All operations issue subcommands of `PK_CMD_MATRIX_KEYBOARD_CFG` (`0xCA`).
+
+## Command reference
+
+### PK_MatrixKBConfigurationGet
+* **Subcommand**: `10`
+* **Response fields**: returns keyboard dimensions, pin assignments and macro mapping options.
+* **Additional fetches**: subcommands `12`‑`19` and `32`‑`39` retrieve key codes and optional triggered mappings.
+
+### PK_MatrixKBConfigurationSet
+* **Subcommands**: `1`, `50`, `2`‑`9` and `22`‑`29`.
+* **Request payload**: configuration values from `sMatrixKeyboard` including pin lists, macro mapping and key codes.
+* **Final step**: resend subcommand `1` with the activation flag enabled.
+
+### PK_MatrixKBStatusGet
+* **Subcommand**: `20`
+* **Response fields**: bytes 8‒23 contain a bit mask for the pressed keys which updates `matrixKBvalues`.


### PR DESCRIPTION
## Summary
- document Matrix Keyboard helper functions
- add MatrixKeyboard_commands.md with subcommand details

## Testing
- `make -f Makefile.noqmake -n`

------
https://chatgpt.com/codex/tasks/task_e_684f04f0920083229717377483f6c687