### PR TITLE
Add matrix LED documentation

### DIFF
--- a/PoKeysLib.h
+++ b/PoKeysLib.h
@@ -1308,11 +1308,37 @@ POKEYSDECL int32_t PK_LCDEntryModeSet(sPoKeysDevice* device, uint8_t cursorMoveD
 // Change LCD display on/off control register
 POKEYSDECL int32_t PK_LCDDisplayOnOffControl(sPoKeysDevice* device, uint8_t displayOnOff, uint8_t cursorOnOff, uint8_t cursorBlinking);
 
-// Set matrix LED configuration
+/**
+ * Write the matrix LED configuration to the device.
+ *
+ * Enabled displays as well as their row and column counts are taken from
+ * the ::sPoKeysDevice::MatrixLED array and encoded into a
+ * `PK_CMD_MATRIX_LED_CONFIGURATION` request.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_MatrixLEDConfigurationSet(sPoKeysDevice* device);
-// Get matrix LED configuration
+/**
+ * Read matrix LED configuration from the device.
+ *
+ * Populates the ::sPoKeysDevice::MatrixLED fields for each available
+ * display using `PK_CMD_MATRIX_LED_CONFIGURATION` with subcommand `1`.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_MatrixLEDConfigurationGet(sPoKeysDevice* device);
-// Update matrix LED (only the displays with refresh flag set)
+/**
+ * Update matrix LED contents on the device.
+ *
+ * For every display that has ::sPoKeysMatrixLED::RefreshFlag set, the
+ * pixel buffer from ::sPoKeysMatrixLED::data is transmitted via
+ * `PK_CMD_MATRIX_LED_UPDATE`.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_MatrixLEDUpdate(sPoKeysDevice* device);
 
 // Pulse engine v2 commands

--- a/README.md
+++ b/README.md
@@ -158,6 +158,15 @@ The library now supports PoKeys security management:
 - **PK_MatrixKBStatusGet**
   - Updates `device->matrixKB.matrixKBvalues` with the currently pressed keys.
 
+## Matrix LED Functions
+
+- **PK_MatrixLEDConfigurationSet**
+  - Sends the enable flags and geometry from `device->MatrixLED` to the device.
+- **PK_MatrixLEDConfigurationGet**
+  - Reads back the display configuration into `device->MatrixLED`.
+- **PK_MatrixLEDUpdate**
+  - Transfers pixel data for displays where `RefreshFlag` is set.
+
 ## Asynchronous IO Wrappers
 
 - **PK_PinConfigurationGetAsync**

--- a/docs/MatrixLED_commands.md
+++ b/docs/MatrixLED_commands.md
@@ -1,0 +1,18 @@
+# Matrix LED Commands
+
+This document summarises the helper functions implemented in **PoKeysLibMatrixLED.c**.
+All operations use `PK_CMD_MATRIX_LED_CONFIGURATION` (`0xD5`) or `PK_CMD_MATRIX_LED_UPDATE` (`0xD6`).
+
+## Command reference
+
+### PK_MatrixLEDConfigurationSet
+* **Command ID**: `PK_CMD_MATRIX_LED_CONFIGURATION (0xD5)` with subcommand `0`.
+* **Request payload**: enable flags, row counts and column counts taken from `sPoKeysMatrixLED`.
+
+### PK_MatrixLEDConfigurationGet
+* **Command ID**: `PK_CMD_MATRIX_LED_CONFIGURATION (0xD5)` with subcommand `1`.
+* **Response fields**: returns display enable bits and geometry for each matrix display.
+
+### PK_MatrixLEDUpdate
+* **Command ID**: `PK_CMD_MATRIX_LED_UPDATE (0xD6)`.
+* **Request payload**: eight bytes of pixel data from `sPoKeysMatrixLED.data` for each display with a set refresh flag.


### PR DESCRIPTION
## Summary
- document PK_MatrixLEDConfigurationSet/Get/Update in PoKeysLib.h
- add README section describing Matrix LED helper routines
- create docs/MatrixLED_commands.md with command details

## Testing
- `make -f Makefile.noqmake`
- `make -f Makefile.noqmake clean`

------
https://chatgpt.com/codex/tasks/task_e_684f09d190548322a3d9416c5883e88c