### PR TITLE
Add failsafe documentation

### DIFF
--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -1518,8 +1518,26 @@ POKEYSDECL int32_t PK_EasySensorsSetupSet(sPoKeysDevice* device);
  */
 POKEYSDECL int32_t PK_EasySensorsValueGetAll(sPoKeysDevice* device);
 
-// Failsafe settings
+/**
+ * Retrieve failsafe configuration from the device.
+ *
+ * Populates the ::sPoKeysFailsafeSettings structure of @p device with the
+ * current timeout and output values that will be applied when the connection
+ * watchdog expires.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_FailsafeSettingsGet(sPoKeysDevice* device);
+/**
+ * Send failsafe configuration to the device.
+ *
+ * Writes the failsafe configuration stored in the ::sPoKeysDevice structure
+ * back to the connected PoKeys device.
+ *
+ * @param device Pointer to an initialized device structure.
+ * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
+ */
 POKEYSDECL int32_t PK_FailsafeSettingsSet(sPoKeysDevice* device);
 
 // SPI operations

--- a/docs/Failsafe_commands.md
+++ b/docs/Failsafe_commands.md
@@ -1,0 +1,13 @@
+# Failsafe Settings Commands
+
+This document summarises the helper functions implemented in **PoKeysLibFailsafe.c**. All operations use command `0x81`.
+
+## Command reference
+
+### PK_FailsafeSettingsGet
+* **Subcommand**: `0`
+* **Response fields**: returns timeout, peripheral enable bits and output values stored in `sPoKeysFailsafeSettings`.
+
+### PK_FailsafeSettingsSet
+* **Subcommand**: `1`
+* **Request payload**: settings from `sPoKeysFailsafeSettings` are written back to the device.


### PR DESCRIPTION
## Summary
- document failsafe helpers in the public header
- add command reference for failsafe functions

## Testing
- `make -f Makefile.noqmake`

------
https://chatgpt.com/codex/tasks/task_e_684f1640d39883228498c45b299713c0