### PR TITLE
Add async EasySensors support

### DIFF
--- a/Makefile.noqmake
+++ b/Makefile.noqmake
@@ -10,7 +10,7 @@ SOURCES=PoKeysLibCore.c hid-libusb.c PoKeysLibFastUSB.c \
         PoKeysLibIO.c PoKeysLibIOAsync.c \
         PoKeysLibEncoders.c PoKeysLibMatrixLED.c PoKeysLibMatrixKB.c \
         PoKeysLibPoNET.c PoKeysLibLCD.c PoKeysLibRTC.c \
-        PoKeysLibEasySensors.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
+        PoKeysLibEasySensors.c PoKeysLibEasySensorsAsync.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
         PoKeysLibPulseEngine_v2.c \
         PoKeysLibUART.c \
         PoKeysLibCAN.c \

--- a/Makefile.noqmake.osx
+++ b/Makefile.noqmake.osx
@@ -8,7 +8,7 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-mac.c PoKeysLibFastUSB.c \
         PoKeysLibDeviceData.c PoKeysLibDeviceDataAsync.c \
         PoKeysLibIO.c PoKeysLibEncoders.c PoKeysLibMatrixLED.c PoKeysLibMatrixKB.c \
         PoKeysLibPoNET.c PoKeysLibLCD.c PoKeysLibRTC.c \
-        PoKeysLibEasySensors.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
+        PoKeysLibEasySensors.c PoKeysLibEasySensorsAsync.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
         PoKeysLibPulseEngine_v2.c \
         PoKeysLibUART.c \
         PoKeysLibCAN.c \

--- a/Makefile.noqmakeRT
+++ b/Makefile.noqmakeRT
@@ -7,7 +7,7 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c PoKeysLibFastUSB.c \
         PoKeysLibDeviceData.c PoKeysLibDeviceDataAsync.c \
         PoKeysLibIO.c PoKeysLibEncoders.c PoKeysLibMatrixLED.c PoKeysLibMatrixKB.c \
         PoKeysLibPoNET.c PoKeysLibLCD.c PoKeysLibRTC.c \
-        PoKeysLibEasySensors.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
+        PoKeysLibEasySensors.c PoKeysLibEasySensorsAsync.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
         PoKeysLibPulseEngine_v2.c \
         PoKeysLibUART.c \
         PoKeysLibCAN.c \

--- a/PoKeysLibEasySensorsAsync.c
+++ b/PoKeysLibEasySensorsAsync.c
@@ -1,0 +1,129 @@
+/*
+ * Asynchronous EasySensors helpers using the PoKeysLibAsync framework.
+ *
+ * These functions mirror the blocking EasySensors routines in
+ * PoKeysLibEasySensors.c but avoid any blocking socket I/O.
+ * Designed for realtime usage with minimal CPU overhead and
+ * asynchronous non-blocking communication.
+ */
+
+#include "PoKeysLibHal.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+typedef struct {
+    sPoKeysEasySensor *sensor_ptr; /* pointer to first sensor in this request */
+    uint8_t count;                 /* number of sensors parsed */
+    uint8_t used;
+} EasySensorAsyncContext;
+
+static EasySensorAsyncContext es_ctx[256];
+
+/* Parse EasySensor configuration response */
+static int PK_EasySensorSetup_Parse(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    uint8_t id = resp[6];
+    EasySensorAsyncContext *c = &es_ctx[id];
+    if (!c->sensor_ptr) {
+        c->used = 0;
+        return PK_ERR_GENERIC;
+    }
+    sPoKeysEasySensor *es = c->sensor_ptr;
+    es->sensorValue = 0; /* clear value pointer */
+    es->sensorType = resp[8];
+    es->sensorReadingID = resp[9];
+    es->sensorRefreshPeriod = resp[10];
+    es->sensorFailsafeConfig = resp[11];
+    memcpy(es->sensorID, resp + 12, 8);
+    c->used = 0;
+    return PK_OK;
+}
+
+/* Parse EasySensor values response */
+static int PK_EasySensorValues_Parse(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    uint8_t id = resp[6];
+    EasySensorAsyncContext *c = &es_ctx[id];
+    if (!c->sensor_ptr) {
+        c->used = 0;
+        return PK_ERR_GENERIC;
+    }
+    for (uint8_t t = 0; t < c->count; t++) {
+        sPoKeysEasySensor *es = &c->sensor_ptr[t];
+        *es->sensorValue = ((int32_t)resp[8 + t*4]) |
+                           ((int32_t)resp[8 + t*4 + 1] << 8) |
+                           ((int32_t)resp[8 + t*4 + 2] << 16) |
+                           ((int32_t)resp[8 + t*4 + 3] << 24);
+        es->sensorOKstatus = (resp[4 + t/8] >> (t % 8)) & 1;
+    }
+    c->used = 0;
+    return PK_OK;
+}
+
+int PK_EasySensorsSetupGetAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    if (device->info.iEasySensors == 0) return PK_ERR_NOT_SUPPORTED;
+
+    for (uint32_t i = 0; i < device->info.iEasySensors; i++) {
+        sPoKeysEasySensor *es = &device->EasySensors[i];
+        uint8_t params[4] = { (uint8_t)i, 1, 0, 0 };
+        int req = CreateRequestAsync(device, PK_CMD_SENSORS_SETUP_57,
+                                     params, 4, NULL, 0,
+                                     PK_EasySensorSetup_Parse);
+        if (req < 0) return req;
+        es_ctx[req].sensor_ptr = es;
+        es_ctx[req].count = 1;
+        es_ctx[req].used = 1;
+        int err = SendRequestAsync(device, req);
+        if (err != PK_OK) return err;
+    }
+    return PK_OK;
+}
+
+int PK_EasySensorsSetupSetAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    if (device->info.iEasySensors == 0) return PK_ERR_NOT_SUPPORTED;
+
+    for (uint32_t i = 0; i < device->info.iEasySensors; i++) {
+        sPoKeysEasySensor *es = &device->EasySensors[i];
+        uint8_t params[4] = { (uint8_t)i, 1, 1, 0 };
+        uint8_t payload[12];
+        payload[0] = es->sensorType;
+        payload[1] = es->sensorReadingID;
+        payload[2] = es->sensorRefreshPeriod;
+        payload[3] = es->sensorFailsafeConfig;
+        memcpy(payload + 4, es->sensorID, 8);
+        int req = CreateRequestAsyncWithPayload(device, PK_CMD_SENSORS_SETUP_57,
+                                                params, 4, payload, 12, NULL);
+        if (req < 0) return req;
+        int err = SendRequestAsync(device, req);
+        if (err != PK_OK) return err;
+    }
+    return PK_OK;
+}
+
+int PK_EasySensorsValueGetAllAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    if (device->info.iEasySensors == 0) return PK_ERR_NOT_SUPPORTED;
+
+    for (uint32_t i = 0; i < device->info.iEasySensors; i += 13) {
+        uint8_t readNum = 13;
+        if (i + 13 > device->info.iEasySensors)
+            readNum = device->info.iEasySensors - i;
+        uint8_t params[4] = { (uint8_t)i, readNum, 0, 0 };
+        int req = CreateRequestAsync(device, PK_CMD_SENSOR_VALUES_READ_57,
+                                     params, 4, NULL, 0,
+                                     PK_EasySensorValues_Parse);
+        if (req < 0) return req;
+        es_ctx[req].sensor_ptr = &device->EasySensors[i];
+        es_ctx[req].count = readNum;
+        es_ctx[req].used = 1;
+        int err = SendRequestAsync(device, req);
+        if (err != PK_OK) return err;
+    }
+    return PK_OK;
+}
+

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -1583,6 +1583,11 @@ POKEYSDECL int32_t PK_EasySensorsSetupSet(sPoKeysDevice* device);
  */
 POKEYSDECL int32_t PK_EasySensorsValueGetAll(sPoKeysDevice* device);
 
+// Asynchronous EasySensor API
+int PK_EasySensorsSetupGetAsync(sPoKeysDevice* device);
+int PK_EasySensorsSetupSetAsync(sPoKeysDevice* device);
+int PK_EasySensorsValueGetAllAsync(sPoKeysDevice* device);
+
 /**
  * Retrieve failsafe configuration from the device.
  *


### PR DESCRIPTION
## Summary
- implement `PoKeysLibEasySensorsAsync.c` with non-blocking mailbox transactions
- expose async EasySensors API prototypes in `PoKeysLibHal.h`
- build EasySensors async source in Makefiles

## Testing
- `make -f Makefile.noqmake`
- `make -f Makefile.noqmakeRT` *(fails: No rule to make target 'hal_digital.c')*
- `make -f Makefile.noqmake.osx` *(fails: missing IOKit headers)*

------
https://chatgpt.com/codex/tasks/task_e_68503d69b2ec83229332f7ea012d47df