### PR TITLE
Add asynchronous failsafe handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,13 @@ add_library(PoKeys SHARED
             PoKeysLibCANAsync.c
             PoKeysLibSecurity.c
             PoKeysLibSecurityAsync.c
-            PoKeysLibCOSM.c
-            PoKeysLibCOSMAsync.c
-            PoKeysLibUART.c
-            PoKeysLibWS2812.c
-            PoKeysLibWS2812Async.c)
+             PoKeysLibCOSM.c
+             PoKeysLibCOSMAsync.c
+             PoKeysLibFailsafe.c
+             PoKeysLibFailsafeAsync.c
+             PoKeysLibUART.c
+             PoKeysLibWS2812.c
+             PoKeysLibWS2812Async.c)
 
 install(FILES PoKeysLib.h DESTINATION include)
 install(TARGETS PoKeys DESTINATION lib)

--- a/Makefile.noqmake
+++ b/Makefile.noqmake
@@ -20,7 +20,7 @@ SOURCES=PoKeysLibCore.c hid-libusb.c PoKeysLibFastUSB.c \
         PoKeysLibSecurityAsync.c \
         PoKeysLibCOSM.c \
         PoKeysLibCOSMAsync.c \
-        PoKeysLibFailsafe.c \
+        PoKeysLibFailsafe.c PoKeysLibFailsafeAsync.c \
         PoKeysLibDevicePoKeys57Industrial.c PoKeysLibDevicePoKeys57IndustrialAsync.c \
         PoKeysLibI2CAsync.c PoKeysLib1WireAsync.c \
         PoKeysLibWS2812.c PoKeysLibWS2812Async.c \

--- a/Makefile.noqmake.osx
+++ b/Makefile.noqmake.osx
@@ -18,7 +18,7 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-mac.c PoKeysLibFastUSB.c \
         PoKeysLibSecurityAsync.c \
         PoKeysLibCOSM.c \
         PoKeysLibCOSMAsync.c \
-        PoKeysLibFailsafe.c \
+        PoKeysLibFailsafe.c PoKeysLibFailsafeAsync.c \
         PoKeysLibLCDAsync.c \
         PoKeysLibWS2812.c PoKeysLibWS2812Async.c
 

--- a/Makefile.noqmakeRT
+++ b/Makefile.noqmakeRT
@@ -17,7 +17,7 @@ SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c PoKeysLibFastUSB.c \
         PoKeysLibSecurityAsync.c \
         PoKeysLibCOSM.c \
         PoKeysLibCOSMAsync.c \
-        PoKeysLibFailsafe.c \
+        PoKeysLibFailsafe.c PoKeysLibFailsafeAsync.c \
         PoKeysLibDevicePoKeys57IndustrialAsync.c \
         PoKeysLib1WireAsync.c \
         PoKeysLibWS2812.c PoKeysLibWS2812Async.c \

--- a/PoKeysLib.h
+++ b/PoKeysLib.h
@@ -1507,6 +1507,8 @@ POKEYSDECL int32_t PK_EasySensorsValueGetAll(sPoKeysDevice* device);
 // Failsafe settings
 POKEYSDECL int32_t PK_FailsafeSettingsGet(sPoKeysDevice* device);
 POKEYSDECL int32_t PK_FailsafeSettingsSet(sPoKeysDevice* device);
+int PK_FailsafeSettingsGetAsync(sPoKeysDevice* device);
+int PK_FailsafeSettingsSetAsync(sPoKeysDevice* device);
 
 // SPI operations
 POKEYSDECL int32_t PK_SPIConfigure(sPoKeysDevice * device, uint8_t prescaler, uint8_t frameFormat);

--- a/PoKeysLib.pro
+++ b/PoKeysLib.pro
@@ -59,6 +59,7 @@ SOURCES += PoKeysLibCore.c \
     PoKeysLibCAN.c \
     PoKeysLibWS2812.c \
     PoKeysLibFailsafe.c \
+    PoKeysLibFailsafeAsync.c \
     PoKeysLibDevicePoKeys57Industrial.c \
     PoKeysLibDevicePoKeys57IndustrialAsync.c
 

--- a/PoKeysLibFailsafeAsync.c
+++ b/PoKeysLibFailsafeAsync.c
@@ -1,0 +1,57 @@
+#include "PoKeysLibHal.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+/*
+ * Asynchronous failsafe configuration helpers.
+ *
+ * These wrappers mirror PK_FailsafeSettingsGet and
+ * PK_FailsafeSettingsSet but queue the UDP requests using the
+ * generic async framework so the caller never blocks while
+ * waiting for network traffic. This design is realtime-safe.
+ */
+
+static int PK_Failsafe_Parse(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    if (!dev || !resp) return PK_ERR_GENERIC;
+
+    dev->failsafeSettings.bFailSafeEnabled    = resp[3];
+    dev->failsafeSettings.bFailSafePeripherals = resp[4];
+
+    memcpy(dev->failsafeSettings.bFailSafeIO,       resp + 8, 7);
+    memcpy(dev->failsafeSettings.bFailSafePoExtBus, resp + 15, 10);
+    memcpy(dev->failsafeSettings.bFailSafePWM,      resp + 25, 6);
+    return PK_OK;
+}
+
+int PK_FailsafeSettingsGetAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    uint8_t params[1] = { 0x00 }; /* subcommand 0 */
+    int req = CreateRequestAsync(device, PK_CMD_FAILSAFE_SETTINGS,
+                                 params, 1, NULL, 0,
+                                 PK_Failsafe_Parse);
+    if (req < 0) return req;
+    return SendRequestAsync(device, req);
+}
+
+int PK_FailsafeSettingsSetAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    uint8_t params[4] = { 0x01,
+                          device->failsafeSettings.bFailSafeEnabled,
+                          device->failsafeSettings.bFailSafePeripherals,
+                          0 };
+
+    uint8_t payload[23];
+    memcpy(payload, device->failsafeSettings.bFailSafeIO, 7);
+    memcpy(payload + 7, device->failsafeSettings.bFailSafePoExtBus, 10);
+    memcpy(payload + 17, device->failsafeSettings.bFailSafePWM, 6);
+
+    int req = CreateRequestAsyncWithPayload(device, PK_CMD_FAILSAFE_SETTINGS,
+                                            params, 4, payload, sizeof(payload),
+                                            NULL);
+    if (req < 0) return req;
+    return SendRequestAsync(device, req);
+}
+

--- a/PoKeysLibHal.h
+++ b/PoKeysLibHal.h
@@ -1609,6 +1609,8 @@ POKEYSDECL int32_t PK_FailsafeSettingsGet(sPoKeysDevice* device);
  * @return ::PK_OK on success or a negative ::PK_ERR code on failure.
  */
 POKEYSDECL int32_t PK_FailsafeSettingsSet(sPoKeysDevice* device);
+int PK_FailsafeSettingsGetAsync(sPoKeysDevice* device);
+int PK_FailsafeSettingsSetAsync(sPoKeysDevice* device);
 
 // SPI operations
 POKEYSDECL int32_t PK_SPIConfigure(sPoKeysDevice * device, uint8_t prescaler, uint8_t frameFormat);

--- a/docs/Failsafe_commands.md
+++ b/docs/Failsafe_commands.md
@@ -11,3 +11,12 @@ This document summarises the helper functions implemented in **PoKeysLibFailsafe
 ### PK_FailsafeSettingsSet
 * **Subcommand**: `1`
 * **Request payload**: settings from `sPoKeysFailsafeSettings` are written back to the device.
+
+## Asynchronous API
+
+For realtime tasks the following wrappers in `PoKeysLibFailsafeAsync.c` perform
+the same operations without waiting for network I/O. Each call schedules the
+request with `CreateRequestAsync` and returns immediately.
+
+- `PK_FailsafeSettingsGetAsync`
+- `PK_FailsafeSettingsSetAsync`


### PR DESCRIPTION
## Summary
- introduce `PoKeysLibFailsafeAsync.c` with realtime-safe helpers
- expose async failsafe APIs in headers
- document async failsafe functions
- include new source in build files

## Testing
- `make -f Makefile.noqmakeRT` *(fails: No rule to make target 'hal_digital.c')*

------
https://chatgpt.com/codex/tasks/task_e_68505b5b75b4832295bb5a783277dcdd