### PR TITLE
Add async MatrixLED wrappers

### DIFF
--- a/Makefile.noqmake
+++ b/Makefile.noqmake
@@ -9,7 +9,7 @@ SOURCES=PoKeysLibCore.c hid-libusb.c PoKeysLibFastUSB.c \
         PoKeysLibAsync.c \
         PoKeysLibIO.c PoKeysLibIOAsync.c \
         PoKeysLibEncoders.c PoKeysLibMatrixLED.c PoKeysLibMatrixKB.c \
-        PoKeysLibMatrixKBAsync.c \
+        PoKeysLibMatrixKBAsync.c PoKeysLibMatrixLEDAsync.c \
         PoKeysLibPoNET.c PoKeysLibLCD.c PoKeysLibRTC.c \
         PoKeysLibEasySensors.c PoKeysLibEasySensorsAsync.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
         PoKeysLibPulseEngine_v2.c \

--- a/Makefile.noqmake.osx
+++ b/Makefile.noqmake.osx
@@ -7,7 +7,7 @@ LDFLAGS=-lusb-1.0 -framework IOKit -framework CoreFoundation -L/usr/lib/ -L/opt/
 SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c hid-mac.c PoKeysLibFastUSB.c \
         PoKeysLibDeviceData.c PoKeysLibDeviceDataAsync.c \
         PoKeysLibIO.c PoKeysLibEncoders.c PoKeysLibMatrixLED.c PoKeysLibMatrixKB.c \
-        PoKeysLibMatrixKBAsync.c \
+        PoKeysLibMatrixKBAsync.c PoKeysLibMatrixLEDAsync.c \
         PoKeysLibPoNET.c PoKeysLibLCD.c PoKeysLibRTC.c \
         PoKeysLibEasySensors.c PoKeysLibEasySensorsAsync.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
         PoKeysLibPulseEngine_v2.c \

--- a/Makefile.noqmakeRT
+++ b/Makefile.noqmakeRT
@@ -6,7 +6,7 @@ LDFLAGS=-lpthread
 SOURCES=PoKeysLibCore.c PoKeysLibCoreSockets.c PoKeysLibFastUSB.c \
         PoKeysLibDeviceData.c PoKeysLibDeviceDataAsync.c \
         PoKeysLibIO.c PoKeysLibEncoders.c PoKeysLibMatrixLED.c PoKeysLibMatrixKB.c \
-        PoKeysLibMatrixKBAsync.c \
+        PoKeysLibMatrixKBAsync.c PoKeysLibMatrixLEDAsync.c \
         PoKeysLibPoNET.c PoKeysLibLCD.c PoKeysLibRTC.c \
         PoKeysLibEasySensors.c PoKeysLibEasySensorsAsync.c PoKeysLibI2C.c PoKeysLib1Wire.c PoKeysLibSPI.c \
         PoKeysLibPulseEngine_v2.c \

--- a/PoKeysLibMatrixLEDAsync.c
+++ b/PoKeysLibMatrixLEDAsync.c
@@ -1,0 +1,92 @@
+/*
+ * PoKeysLibMatrixLEDAsync.c
+ *
+ * Asynchronous wrappers for matrix LED configuration and display updates.
+ * These functions mirror the behaviour of the blocking API in
+ * PoKeysLibMatrixLED.c but use the PoKeysLibAsync infrastructure so
+ * callers never block waiting for UDP traffic.
+ *
+ * Each call only places a packet into the async transmit queue.
+ * The receive dispatcher fills the device structure when responses
+ * arrive which keeps realtime threads deterministic and responsive.
+ */
+
+#include "PoKeysLibHal.h"
+#include "PoKeysLibAsync.h"
+#include <string.h>
+
+static int PK_MLED_ConfigParse(sPoKeysDevice *dev, const uint8_t *resp)
+{
+    if (!dev || !resp)
+        return PK_ERR_GENERIC;
+
+    dev->MatrixLED[0].displayEnabled = (resp[3] & 1) ? 1 : 0;
+    dev->MatrixLED[0].rows          = resp[4] & 0x0F;
+    dev->MatrixLED[0].columns       = (resp[4] >> 4) & 0x0F;
+
+    dev->MatrixLED[1].displayEnabled = (resp[3] & 2) ? 1 : 0;
+    dev->MatrixLED[1].rows          = resp[5] & 0x0F;
+    dev->MatrixLED[1].columns       = (resp[5] >> 4) & 0x0F;
+    return PK_OK;
+}
+
+int PK_MatrixLEDConfigurationGetAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    if (device->info.iMatrixLED == 0) return PK_ERR_NOT_SUPPORTED;
+
+    uint8_t params[1] = { 1 }; /* subcommand: read */
+    int req = CreateRequestAsync(device, PK_CMD_MATRIX_LED_CONFIGURATION,
+                                 params, 1, NULL, 0,
+                                 PK_MLED_ConfigParse);
+    if (req < 0)
+        return req;
+    return SendRequestAsync(device, (uint8_t)req);
+}
+
+int PK_MatrixLEDConfigurationSetAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    if (device->info.iMatrixLED == 0) return PK_ERR_NOT_SUPPORTED;
+
+    uint8_t params[4];
+    params[0] = 0; /* subcommand: write */
+    params[1] = (device->MatrixLED[0].displayEnabled ? 1 : 0) |
+                (device->MatrixLED[1].displayEnabled ? 2 : 0);
+    params[2] = (device->MatrixLED[0].rows & 0x0F) |
+                ((device->MatrixLED[0].columns & 0x0F) << 4);
+    params[3] = (device->MatrixLED[1].rows & 0x0F) |
+                ((device->MatrixLED[1].columns & 0x0F) << 4);
+
+    int req = CreateRequestAsync(device, PK_CMD_MATRIX_LED_CONFIGURATION,
+                                 params, 4, NULL, 0, NULL);
+    if (req < 0)
+        return req;
+    return SendRequestAsync(device, (uint8_t)req);
+}
+
+int PK_MatrixLEDUpdateAsync(sPoKeysDevice* device)
+{
+    if (!device) return PK_ERR_NOT_CONNECTED;
+    if (device->info.iMatrixLED == 0) return PK_ERR_NOT_SUPPORTED;
+
+    uint8_t displayCode[] = { 1, 11 };
+    for (uint8_t i = 0; i < device->info.iMatrixLED && i < 2; i++) {
+        if (device->MatrixLED[i].RefreshFlag) {
+            uint8_t params[1] = { displayCode[i] };
+            int req = CreateRequestAsyncWithPayload(device,
+                        PK_CMD_MATRIX_LED_UPDATE,
+                        params, 1,
+                        device->MatrixLED[i].data, 8,
+                        NULL);
+            if (req < 0)
+                return req;
+            int r = SendRequestAsync(device, (uint8_t)req);
+            if (r < 0)
+                return r;
+            device->MatrixLED[i].RefreshFlag = 0;
+        }
+    }
+    return PK_OK;
+}
+

--- a/docs/MatrixLED_commands.md
+++ b/docs/MatrixLED_commands.md
@@ -16,3 +16,13 @@ All operations use `PK_CMD_MATRIX_LED_CONFIGURATION` (`0xD5`) or `PK_CMD_MATRIX_
 ### PK_MatrixLEDUpdate
 * **Command ID**: `PK_CMD_MATRIX_LED_UPDATE (0xD6)`.
 * **Request payload**: eight bytes of pixel data from `sPoKeysMatrixLED.data` for each display with a set refresh flag.
+
+## Asynchronous API
+
+`PoKeysLibMatrixLEDAsync.c` provides non-blocking wrappers for realtime use. Calls return immediately after queueing the UDP packet so the caller never waits for network activity.
+
+- `PK_MatrixLEDConfigurationGetAsync`
+- `PK_MatrixLEDConfigurationSetAsync`
+- `PK_MatrixLEDUpdateAsync`
+
+The dispatcher updates `sPoKeysMatrixLED` when responses arrive, ensuring deterministic realtime behaviour without blocking the thread that requests an update.


### PR DESCRIPTION
## Summary
- implement async configuration and update helpers for matrix LED
- compile new file via Makefiles
- document realtime-friendly MatrixLED async API

## Testing
- `make -f Makefile.noqmake`

------
https://chatgpt.com/codex/tasks/task_e_68514ce59ca0832293f30c089ab89882