### PR TITLE
feat: HIL-TDD infrastructure skeleton (issue #138)

### DIFF
--- a/.github/agents/tdd-driver.agent.md
+++ b/.github/agents/tdd-driver.agent.md
@@ -453,4 +453,18 @@ A well-implemented feature should:
 
 ---
 
+## Hardware-dependent testing (PoKeys HIL)
+
+When acceptance criteria depend on actual PoKeys hardware, firmware, physical I/O,
+PEv2 signal propagation, analog conversion, encoder feedback, or measured timing:
+
+1. Use the `hil-tdd` skill.
+2. Select a registered HIL setup by setup ID (e.g., `pokeys57e-loopback-v1`).
+3. Keep software-only unit and protocol tests; HIL does not replace them.
+4. Never report an unavailable or skipped HIL test as passing.
+5. Do not operate hardware outside the capabilities declared by the selected setup.
+6. Run unit tests before HIL. A failing unit test is not a justification to skip to HIL.
+
+---
+
 *You are the disciplined craftsman. Test first. Code minimal. Refactor relentlessly. Integrate continuously. Quality through discipline!* ⚡

--- a/.github/agents/testing-specialist.agent.md
+++ b/.github/agents/testing-specialist.agent.md
@@ -398,4 +398,17 @@ Well-tested code should have:
 
 ---
 
+## Hardware-dependent testing (PoKeys HIL)
+
+When acceptance criteria depend on actual PoKeys hardware, firmware, physical I/O,
+PEv2 signal propagation, analog conversion, encoder feedback, or measured timing:
+
+1. Use the `hil-tdd` skill.
+2. Select a registered HIL setup by setup ID (e.g., `pokeys57e-loopback-v1`).
+3. Keep software-only unit and protocol tests; HIL does not replace them.
+4. Never report an unavailable or skipped HIL test as passing.
+5. Do not operate hardware outside the capabilities declared by the selected setup.
+
+---
+
 *You are the quality guardian. Every line of code deserves a test. Coverage is not just a metric—it's confidence!* 🧪

--- a/.github/instructions/hil-tdd.instructions.md
+++ b/.github/instructions/hil-tdd.instructions.md
@@ -7,58 +7,30 @@ applyTo: "tests/hil/**"
 
 HIL tests verify real hardware behavior; they do not replace host unit tests.
 
-## Fixture runnable gate
+## Fixture gate
 
 Never run a fixture whose YAML does not have `runnable: true` and
-`fixture_status: verified`. A draft fixture must not be used for automated runs.
+`fixture_status: verified`. Draft fixtures are not valid for automation.
 
-## Anti-contention rule
-
-- Before enabling a source as an output, verify the destination is configured as
-  an input, counter, analog input, or declared peripheral input.
-- At most one endpoint of a physical loopback may be an active output at any time.
-- If endpoint direction cannot be verified, do not energize the loopback.
-- Series resistors (1–4.7 kΩ) are required at each direct GPIO loopback.
-
-## Safety rules
+## Safety
 
 - Acquire exclusive fixture access before changing any output.
-- Safe state is defined per channel in the fixture YAML (`safe_logical_value`,
-  `expected_safe_physical_level`). `false` ≠ electrically inactive for inverted outputs.
-- Establish and verify the safe state on all source channels before any test.
-- Manipulate only outputs declared in the setup capability list.
-- Motion, pulse-engine, and emergency tests require explicit setup declaration.
-- Restore all source channels to safe state on teardown, even after failure.
-- Unload HAL components and release the fixture lock after every run.
+- Verify the per-channel safe state from the fixture YAML before each run.
+- Never energize a loopback unless the destination is configured as an input or declared peripheral input.
+- Restore safe state on teardown and unload HAL components after the run.
 
-## Primitive HIL — prohibited loads
+## Scope
 
-`tests/hil/basic/` must not load: `motmod`, kinematics, AXIS UI,
-`DM542_XXYZ_mill`, `pokeys_homing.hal`, or `wcomp`.
-Machine config tests belong in `tests/hil/machine/linuxcnc/`.
+`tests/hil/basic/` is for primitive driver tests only; `tests/hil/machine/linuxcnc/` is for full machine integration.
 
-## Preflight outcomes
+## Outcomes and evidence terms
 
-| Condition | Result |
-|---|---|
-| `POKEYS_HIL` not set | SKIPPED |
-| Non-HIL runner | SKIPPED |
-| HIL requested but device absent / identity mismatch / revision mismatch | ERROR |
-| Continuity/self-test fails | ERROR |
-| Behavior differs from expectation | FAIL |
-| Success | PASS |
-
-A required HIL job that produces zero test results must not be green.
+Use `.github/skills/hil-tdd/references/result-schema.md`.
+A required HIL job that produces zero results must not be green.
 
 ## Oracle traceability
 
 Unit tests for hardware-facing behavior must cite a verified observation or spec.
-Include: `/* Oracle: HIL-P57E-DIO-001 */`
-Physical pin N = HAL channel index N−1. Never treat them as identical.
-
-## Status terms — see `../skills/hil-tdd/references/result-schema.md`
-
-`HIL-observed` · `HIL-test-executed` · `HIL-verified` · `Timing-validated`
-Do not redefine `RT-validated`; the engineering contract owns that term.
+Include `/* Oracle: HIL-P57E-DIO-001 */`. Physical pin N != HAL channel index N−1.
 
 

--- a/.github/instructions/hil-tdd.instructions.md
+++ b/.github/instructions/hil-tdd.instructions.md
@@ -16,7 +16,9 @@ Never run a fixture whose YAML does not have `runnable: true` and
 
 - Acquire exclusive fixture access before changing any output.
 - Verify the per-channel safe state from the fixture YAML before each run.
-- Never energize a loopback unless the destination is configured as an input or declared peripheral input.
+- At most one endpoint of a physical loopback may be an active output.
+- If the destination mode cannot be verified, do not energize the source.
+- Direct GPIO loopbacks require confirmed series-current protection before unattended automation.
 - Restore safe state on teardown and unload HAL components after the run.
 
 ## Scope
@@ -31,6 +33,6 @@ A required HIL job that produces zero results must not be green.
 ## Oracle traceability
 
 Unit tests for hardware-facing behavior must cite a verified observation or spec.
-Include `/* Oracle: HIL-P57E-DIO-001 */`. Physical pin N != HAL channel index N−1.
+Include `/* Oracle: HIL-P57E-DIO-001 */`. Physical pin N maps to HAL channel index N−1; store and report both values separately.
 
 

--- a/.github/instructions/hil-tdd.instructions.md
+++ b/.github/instructions/hil-tdd.instructions.md
@@ -5,95 +5,60 @@ applyTo: "tests/hil/**"
 
 # PoKeys HIL-TDD Contract
 
-## Purpose
+HIL tests verify real hardware behavior; they do not replace host unit tests.
 
-The PoKeys57E HIL fixture verifies real hardware behavior through a fixed loopback
-wiring harness. It validates that PoKeysHal exports the expected HAL pins, applies
-the expected pin functions, drives physical outputs, and observes physical inputs.
+## Fixture runnable gate
 
-HIL tests are acceptance/verification tests. They do not replace host unit tests.
+Never run a fixture whose YAML does not have `runnable: true` and
+`fixture_status: verified`. A draft fixture must not be used for automated runs.
 
-## Fixture identity
+## Anti-contention rule
 
-- Every HIL test must reference a registered setup ID and revision (e.g., `pokeys57e-loopback-v1`).
-- Never run against a device whose model or identity does not match the selected setup.
-- A missing device, failed preflight, or unavailable runner is SKIPPED/NOT RUN, never PASS.
+- Before enabling a source as an output, verify the destination is configured as
+  an input, counter, analog input, or declared peripheral input.
+- At most one endpoint of a physical loopback may be an active output at any time.
+- If endpoint direction cannot be verified, do not energize the loopback.
+- Series resistors (1–4.7 kΩ) are required at each direct GPIO loopback.
 
 ## Safety rules
 
 - Acquire exclusive fixture access before changing any output.
-- Establish and verify the safe output state (all outputs false/inactive) before and after every test.
-- Tests must manipulate only outputs declared by the setup capability list.
-- Motion, pulse-engine, and emergency tests are disabled unless explicitly declared safe by the setup.
-- Restore all outputs to their safe state on teardown, even after failure.
-- Disable any PEv2 operations started by the test on cleanup.
-- Unload test HAL components and release the fixture lock after every run.
+- Safe state is defined per channel in the fixture YAML (`safe_logical_value`,
+  `expected_safe_physical_level`). `false` ≠ electrically inactive for inverted outputs.
+- Establish and verify the safe state on all source channels before any test.
+- Manipulate only outputs declared in the setup capability list.
+- Motion, pulse-engine, and emergency tests require explicit setup declaration.
+- Restore all source channels to safe state on teardown, even after failure.
+- Unload HAL components and release the fixture lock after every run.
 
-## Scope: primitive HIL vs integration
+## Primitive HIL — prohibited loads
 
-Primitive HIL tests (`tests/hil/basic/`) must verify driver hardware-facing contracts
-with the smallest possible HAL setup. They must NOT load:
+`tests/hil/basic/` must not load: `motmod`, kinematics, AXIS UI,
+`DM542_XXYZ_mill`, `pokeys_homing.hal`, or `wcomp`.
+Machine config tests belong in `tests/hil/machine/linuxcnc/`.
 
-- `motmod`, kinematics (`trivkins`, gantry), or AXIS UI
-- the full `DM542_XXYZ_mill` HAL/INI stack
-- `pokeys_homing.hal`
-- `wcomp` window-comparator simulated switches
+## Preflight outcomes
 
-The `DM542_XXYZ_mill` configuration and `wcomp` logic belong in
-`tests/integration/linuxcnc/`, not in `tests/hil/basic/`.
-
-## Status vocabulary
-
-Use precise status terms only:
-
-| Term | Meaning |
+| Condition | Result |
 |---|---|
-| `HIL-observed` | Real board behavior was observed and recorded as a unit-test oracle |
-| `HIL-tested` | The implementation was run against the physical fixture via an automated test |
-| `HIL-verified` | A named HIL test passed against the named setup — does not imply RT-validated |
-| `RT-validated` | Timing was measured on the RT path with a documented threshold |
+| `POKEYS_HIL` not set | SKIPPED |
+| Non-HIL runner | SKIPPED |
+| HIL requested but device absent / identity mismatch / revision mismatch | ERROR |
+| Continuity/self-test fails | ERROR |
+| Behavior differs from expectation | FAIL |
+| Success | PASS |
 
-Never claim `HIL-tested` from a mock, simulator, userspace-only run, or static review.
+A required HIL job that produces zero test results must not be green.
 
 ## Oracle traceability
 
-Unit tests for hardware-facing behavior must not be based on developer assumption.
-Before writing or changing a unit test expectation for any of the following, cite
-a HIL observation or protocol specification:
+Unit tests for hardware-facing behavior must cite a verified observation or spec.
+Include: `/* Oracle: HIL-P57E-DIO-001 */`
+Physical pin N = HAL channel index N−1. Never treat them as identical.
 
-- physical pin number to HAL channel index mapping
-- digin/digout polarity and inversion semantics
-- PEv2 limit/home/emergency switch mapping
-- PWM/adcout scaling and analog input settling
-- async update latency and timeout behavior
-- behavior after disconnect/reconnect
+## Status terms — see `skills/hil-tdd/references/result-schema.md`
 
-Include a traceability comment: `/* Oracle: HIL-P57E-DIO-001 */`
+`HIL-observed` · `HIL-test-executed` · `HIL-verified` · `Timing-validated`
+Do not redefine `RT-validated`; the engineering contract owns that term.
 
-## Evidence required per HIL run
 
-Every HIL run must record: commit SHA, setup ID and revision, device model and ID,
-firmware version, LinuxCNC version, kernel/RT mode, HAL configuration used, test
-command, test result, observed transitions, cleanup result.
-
-## PWM to analog loopback constraint
-
-A directly connected PWM output is a 0/3.3 V square wave, not a DC analog signal.
-An RC low-pass filter (e.g., 4.7 kΩ + 1 µF) is required at each PWM→ADC connection
-for stable duty-cycle-to-voltage tests. Do not assert exact ADC values without a
-measured settling baseline and documented tolerance.
-
-## Emergency loopback
-
-The emergency loopback (Pin 33 → Pin 52) is **excluded from scope** until hardware
-confirmation resolves: (a) the wiring vs `PEv2_EmergencyInputPin=54` discrepancy,
-(b) whether the INI parameter is a physical pin or API index, and (c) the role of
-Pin 54 at startup. See open item HW-1/HW-2 in issue #138.
-
-## Prohibited shortcuts
-
-- Do not treat physical pin numbers and HAL channel indices as identical (physical N = HAL index N−1).
-- Do not use sleep as the only synchronization method where HAL pin polling is possible.
-- Do not run HIL tests on normal GitHub-hosted CI runners.
-- Do not modify production HAL or C source files solely to make a HIL test pass.
-- Do not ignore inverted limit/home semantics — separate raw electrical state from logical PEv2 state.

--- a/.github/instructions/hil-tdd.instructions.md
+++ b/.github/instructions/hil-tdd.instructions.md
@@ -1,0 +1,99 @@
+---
+description: "Mandatory safety and integrity rules for PoKeys hardware-in-the-loop tests."
+applyTo: "tests/hil/**"
+---
+
+# PoKeys HIL-TDD Contract
+
+## Purpose
+
+The PoKeys57E HIL fixture verifies real hardware behavior through a fixed loopback
+wiring harness. It validates that PoKeysHal exports the expected HAL pins, applies
+the expected pin functions, drives physical outputs, and observes physical inputs.
+
+HIL tests are acceptance/verification tests. They do not replace host unit tests.
+
+## Fixture identity
+
+- Every HIL test must reference a registered setup ID and revision (e.g., `pokeys57e-loopback-v1`).
+- Never run against a device whose model or identity does not match the selected setup.
+- A missing device, failed preflight, or unavailable runner is SKIPPED/NOT RUN, never PASS.
+
+## Safety rules
+
+- Acquire exclusive fixture access before changing any output.
+- Establish and verify the safe output state (all outputs false/inactive) before and after every test.
+- Tests must manipulate only outputs declared by the setup capability list.
+- Motion, pulse-engine, and emergency tests are disabled unless explicitly declared safe by the setup.
+- Restore all outputs to their safe state on teardown, even after failure.
+- Disable any PEv2 operations started by the test on cleanup.
+- Unload test HAL components and release the fixture lock after every run.
+
+## Scope: primitive HIL vs integration
+
+Primitive HIL tests (`tests/hil/basic/`) must verify driver hardware-facing contracts
+with the smallest possible HAL setup. They must NOT load:
+
+- `motmod`, kinematics (`trivkins`, gantry), or AXIS UI
+- the full `DM542_XXYZ_mill` HAL/INI stack
+- `pokeys_homing.hal`
+- `wcomp` window-comparator simulated switches
+
+The `DM542_XXYZ_mill` configuration and `wcomp` logic belong in
+`tests/integration/linuxcnc/`, not in `tests/hil/basic/`.
+
+## Status vocabulary
+
+Use precise status terms only:
+
+| Term | Meaning |
+|---|---|
+| `HIL-observed` | Real board behavior was observed and recorded as a unit-test oracle |
+| `HIL-tested` | The implementation was run against the physical fixture via an automated test |
+| `HIL-verified` | A named HIL test passed against the named setup — does not imply RT-validated |
+| `RT-validated` | Timing was measured on the RT path with a documented threshold |
+
+Never claim `HIL-tested` from a mock, simulator, userspace-only run, or static review.
+
+## Oracle traceability
+
+Unit tests for hardware-facing behavior must not be based on developer assumption.
+Before writing or changing a unit test expectation for any of the following, cite
+a HIL observation or protocol specification:
+
+- physical pin number to HAL channel index mapping
+- digin/digout polarity and inversion semantics
+- PEv2 limit/home/emergency switch mapping
+- PWM/adcout scaling and analog input settling
+- async update latency and timeout behavior
+- behavior after disconnect/reconnect
+
+Include a traceability comment: `/* Oracle: HIL-P57E-DIO-001 */`
+
+## Evidence required per HIL run
+
+Every HIL run must record: commit SHA, setup ID and revision, device model and ID,
+firmware version, LinuxCNC version, kernel/RT mode, HAL configuration used, test
+command, test result, observed transitions, cleanup result.
+
+## PWM to analog loopback constraint
+
+A directly connected PWM output is a 0/3.3 V square wave, not a DC analog signal.
+An RC low-pass filter (e.g., 4.7 kΩ + 1 µF) is required at each PWM→ADC connection
+for stable duty-cycle-to-voltage tests. Do not assert exact ADC values without a
+measured settling baseline and documented tolerance.
+
+## Emergency loopback
+
+The emergency loopback (Pin 33 → Pin 52) is **excluded from scope** until hardware
+confirmation resolves: (a) the wiring vs `PEv2_EmergencyInputPin=54` discrepancy,
+(b) whether the INI parameter is a physical pin or API index, and (c) the role of
+Pin 54 at startup. See open item HW-1/HW-2 in issue #138.
+
+## Prohibited shortcuts
+
+- Do not treat physical pin numbers and HAL channel indices as identical (physical N = HAL index N−1).
+- Do not use sleep as the only synchronization method where HAL pin polling is possible.
+- Do not run HIL tests on normal GitHub-hosted CI runners.
+- Do not modify production HAL or C source files solely to make a HIL test pass.
+- Do not ignore inverted limit/home semantics — separate raw electrical state from logical PEv2 state.

--- a/.github/instructions/hil-tdd.instructions.md
+++ b/.github/instructions/hil-tdd.instructions.md
@@ -56,7 +56,7 @@ Unit tests for hardware-facing behavior must cite a verified observation or spec
 Include: `/* Oracle: HIL-P57E-DIO-001 */`
 Physical pin N = HAL channel index N−1. Never treat them as identical.
 
-## Status terms — see `skills/hil-tdd/references/result-schema.md`
+## Status terms — see `../skills/hil-tdd/references/result-schema.md`
 
 `HIL-observed` · `HIL-test-executed` · `HIL-verified` · `Timing-validated`
 Do not redefine `RT-validated`; the engineering contract owns that term.

--- a/.github/prompts/apply-tdd-infrastructure-plan.prompt.md
+++ b/.github/prompts/apply-tdd-infrastructure-plan.prompt.md
@@ -14,6 +14,23 @@ Implement only the approved infrastructure issue:
 
 ${input:issue:Enter the approved GitHub issue number}
 
+## Pre-condition — human approval gate (check before proceeding)
+
+**Do not invoke this prompt automatically or immediately after running
+`tdd-hil-infrastructure-audit.prompt.md`.**
+
+The audit is a planning-only task. Its output must be reviewed and approved
+by a human before any implementation begins. The required sequence is:
+
+1. Run `tdd-hil-infrastructure-audit.prompt.md` (read-only planning).
+2. A human reviews the audit output and makes explicit decisions.
+3. A GitHub issue is created or updated with those decisions as acceptance criteria.
+4. Only then invoke this prompt, supplying that approved issue number.
+
+If the input issue does not contain explicit acceptance criteria derived from
+the approved audit output, stop immediately and request issue updates.
+Do not infer or substitute missing acceptance criteria.
+
 ## Required preparation
 
 1. Read the issue and all acceptance criteria.

--- a/.github/prompts/apply-tdd-infrastructure-plan.prompt.md
+++ b/.github/prompts/apply-tdd-infrastructure-plan.prompt.md
@@ -1,0 +1,78 @@
+---
+name: apply-tdd-infrastructure-plan
+description: >
+  Implement one approved PoKeysHal TDD/Copilot infrastructure issue while excluding
+  hardware operation and HIL test implementation.
+argument-hint: 'issue=<approved GitHub issue number>'
+agent: 'agent'
+tools: ['read', 'search', 'edit', 'execute', 'github/*']
+---
+
+# Task
+
+Implement only the approved infrastructure issue:
+
+${input:issue:Enter the approved GitHub issue number}
+
+## Required preparation
+
+1. Read the issue and all acceptance criteria.
+2. Read:
+   - `docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md`;
+   - the approved infrastructure audit/plan;
+   - current repository instructions;
+   - every customization file affected by the issue.
+3. Establish the current baseline.
+4. Confirm the requested phase does not include hardware operation or HIL test execution.
+5. Create or use the issue-specific branch; never modify `main` directly.
+
+## Scope rules
+
+- Make the smallest complete infrastructure change.
+- Do not add HIL HAL files, fixture scripts, workflows, or hardware tests unless the
+  issue explicitly authorizes that later phase.
+- Do not copy raw thought-document content into active instructions.
+- Preserve one authoritative location per rule.
+- Preserve existing line endings unless normalization is explicitly in scope.
+- Avoid unrelated prompt cleanup.
+- Do not replace unresolved hardware questions with guessed values.
+
+## Customization rules
+
+- Prompt files use current `.prompt.md` frontmatter (`agent`, not `mode`).
+- Prompt files do not use `applyTo`.
+- Path-specific instructions use scalar `applyTo`.
+- Agents contain role/tool/routing guidance, not complete procedures.
+- Skills contain detailed repeatable procedures.
+- Documentation records rationale and decisions.
+- Mandatory safety or evidence invariants remain in appropriately scoped instructions.
+
+## Verification
+
+Run and report:
+
+1. frontmatter parsing for all changed customization files;
+2. search for obsolete file names and routing references;
+3. search for generic web/auth/database examples in rewritten PoKeys TDD files;
+4. line counts before and after;
+5. `git diff --check`;
+6. `git diff --ignore-space-at-eol`;
+7. exact changed-file list;
+8. any available Copilot customization discovery check.
+
+Do not run production build, hardware, RT, or timing tests unless executable code changed.
+
+## Completion report
+
+Report:
+
+- issue implemented;
+- files changed;
+- ownership changes between instruction/prompt/skill/agent/documentation;
+- validation commands and exact results;
+- checks not performed;
+- deferred HIL phases;
+- remaining unresolved hardware facts.
+
+Use `Implemented` and `configuration-validated` precisely. Do not claim
+`HIL-tested`, `hardware-verified`, `RT-validated`, or `timing-validated`.

--- a/.github/prompts/apply-tdd-infrastructure-plan.prompt.md
+++ b/.github/prompts/apply-tdd-infrastructure-plan.prompt.md
@@ -35,7 +35,7 @@ Do not infer or substitute missing acceptance criteria.
 
 1. Read the issue and all acceptance criteria.
 2. Read:
-   - `docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md`;
+   - `docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md` (the canonical synthesis artifact);
    - the approved infrastructure audit/plan;
    - current repository instructions;
    - every customization file affected by the issue.

--- a/.github/prompts/hil-tdd-guidance-synthesize.prompt.md
+++ b/.github/prompts/hil-tdd-guidance-synthesize.prompt.md
@@ -1,0 +1,204 @@
+---
+name: hil-tdd-guidance-synthesize
+description: >
+  Synthesize the PoKeys57E HIL/TDD thought documents into a conflict-resolved,
+  evidence-classified decision basis. Do not edit repository files or implement HIL.
+agent: 'plan'
+tools: ['read', 'search']
+---
+
+# Objective
+
+Produce a decision-quality synthesis of the existing PoKeys57E HIL/TDD material.
+
+This is an analysis task only.
+
+Do not:
+
+- create HIL tests;
+- create HAL or INI files;
+- create workflows;
+- modify instructions, agents, prompts, or skills;
+- operate hardware;
+- silently select one proposal because it is longer or repeated.
+
+## Source documents
+
+Read each source completely:
+
+- [HIL guidance suggestion](../../docs/HIL_Setup_4_TDD/HIL_TDD_guidance_suggestion1.md)
+- [HIL module-test thoughts](../../docs/HIL_Setup_4_TDD/HIL_moduletests_thoughts.md)
+- [PoKeys57E pin modes](../../docs/HIL_Setup_4_TDD/PoKeys57E%20pin%20modes.md)
+- [TDD Guidance 1](../../docs/HIL_Setup_4_TDD/TDD%20Guidance%20for%20PokeysHal1.md)
+- [TDD Guidance 2](../../docs/HIL_Setup_4_TDD/TDD%20Guidance%20for%20PokeysHal2.md)
+- [TDD/HIL guidance thoughts](../../docs/HIL_Setup_4_TDD/TDD_HILguidance_thoughts.md)
+
+Also inspect the current operational context:
+
+- [Root Copilot instructions](../copilot-instructions.md)
+- [Cross-tool agent rules](../../AGENTS.md)
+- [Test instructions](../instructions/tests.instructions.md)
+- [C/RT instructions](../instructions/c-architecture-realtime.instructions.md)
+- [TDD driver agent](../agents/tdd-driver.agent.md)
+- [Testing specialist agent](../agents/testing-specialist.agent.md)
+- [Current TDD prompt](tdd-compile.prompt.md)
+- [Repository audit prompt](repository-audit.prompt.md)
+
+## Interpretation policy
+
+Treat the sources according to this hierarchy.
+
+### Normative product behavior
+
+Requires support from:
+
+1. official PoKeys/PoLabs documentation;
+2. current protocol definitions;
+3. current repository code;
+4. verified upstream `pokeyslib` behavior.
+
+### Physical fixture facts
+
+Require:
+
+1. physically inspected wiring;
+2. a versioned fixture definition;
+3. continuity or controlled loopback verification;
+4. recorded device identity and configuration.
+
+Legacy HAL/INI comments are provenance, not proof of the present fixture.
+
+### Existing repository behavior
+
+Current source, tests, HAL files, INI files, and exported pin names describe the
+current implementation. They do not automatically define the desired behavior.
+
+### Thought and guidance documents
+
+Treat these as candidate proposals. They are not requirements and are not
+independent evidence merely because the same statement appears more than once.
+
+### Previous AI conclusions
+
+Treat conversational phrasing such as "Yes", "Agreed", "should", and
+"recommended" as analysis, not as an accepted project decision.
+
+## Required analysis
+
+### 1. Source inventory
+
+For every source report:
+
+- path;
+- purpose;
+- type: evidence, provenance, proposal, decision, or mixed;
+- duplicate or near-duplicate status;
+- factual claims;
+- recommendations;
+- unresolved assumptions.
+
+Detect exact content duplicates and count them once.
+
+### 2. Claim matrix
+
+Create a table with:
+
+| Claim ID | Claim | Sources | Classification | Evidence | Conflict | Required resolution |
+|---|---|---|---|---|---|---|
+
+Allowed classifications:
+
+- `verified`
+- `supported but not verified`
+- `proposal`
+- `conflicting`
+- `obsolete`
+- `unsafe to assume`
+
+Do not convert a repeated proposal into a verified claim.
+
+### 3. Explicit conflict analysis
+
+At minimum resolve or mark unresolved:
+
+1. Whether HIL is:
+   - the source of selected unit-test oracles;
+   - an outer regression/acceptance layer;
+   - or both under clearly different terms.
+
+2. Whether `wcomp` position-derived switch simulation belongs in:
+   - primitive HIL;
+   - machine integration;
+   - or a later composite HIL layer.
+
+3. Whether the full `DM542_XXYZ_mill` configuration may be used by basic HIL.
+
+4. Pin 33 → Pin 52 versus the INI emergency-input Pin 54 setting.
+
+5. Physical pin numbering versus zero-based HAL channel indexing.
+
+6. PWM terminology:
+   - PWM output;
+   - analog output;
+   - filtered PWM-to-ADC observation.
+
+7. Status vocabulary:
+   - HIL-observed;
+   - HIL-tested;
+   - HIL-verified;
+   - integration-tested;
+   - RT-validated;
+   - timing-validated.
+
+8. Repository placement:
+   - `hil-tests.instructions.md` versus `hil-tdd.instructions.md`;
+   - instruction versus skill;
+   - fixture definition location;
+   - primitive HIL versus machine-integration directories.
+
+9. Whether a dedicated HIL agent is currently justified.
+
+### 4. Decision recommendations
+
+For each conflict, provide:
+
+- recommended decision;
+- rationale;
+- evidence supporting it;
+- consequences;
+- remaining verification needed.
+
+Clearly distinguish:
+
+- decisions that can be made from repository architecture;
+- decisions requiring manual hardware confirmation;
+- decisions requiring official documentation;
+- decisions that should remain deferred.
+
+### 5. Proposed canonical information architecture
+
+Recommend which final documents should exist and what each owns.
+
+The target must avoid keeping six overlapping guidance documents active.
+
+Include proposed dispositions:
+
+- retain as authoritative;
+- merge;
+- convert to historical source note;
+- archive;
+- delete as exact duplicate.
+
+### 6. Output
+
+Return:
+
+1. executive conclusion;
+2. source inventory;
+3. claim/conflict matrix;
+4. recommended decisions;
+5. unresolved hardware questions;
+6. canonical-document proposal;
+7. inputs required for the subsequent infrastructure audit.
+
+Do not produce implementation files or an implementation PR plan yet.

--- a/.github/prompts/tdd-hil-infrastructure-audit.prompt.md
+++ b/.github/prompts/tdd-hil-infrastructure-audit.prompt.md
@@ -1,0 +1,163 @@
+---
+name: tdd-hil-infrastructure-audit
+description: >
+  Audit and redesign the PoKeysHal TDD/Copilot infrastructure using the approved
+  HIL/TDD synthesis. Produce a phased corrective plan; do not implement HIL tests.
+agent: 'plan'
+tools: ['read', 'search']
+---
+
+# Objective
+
+Design the smallest coherent optimization of the repository's TDD and Copilot
+infrastructure that must occur before HIL implementation starts.
+
+This is a planning task only. Do not edit files.
+
+## Authoritative input
+
+Read:
+
+- [Approved HIL/TDD synthesis](../../docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md)
+- [Root Copilot instructions](../copilot-instructions.md)
+- [AGENTS.md](../../AGENTS.md)
+- [Test instructions](../instructions/tests.instructions.md)
+- [Engineering discipline](../instructions/engineering-discipline.instructions.md)
+- [C/RT architecture](../instructions/c-architecture-realtime.instructions.md)
+- [TDD driver agent](../agents/tdd-driver.agent.md)
+- [Testing specialist agent](../agents/testing-specialist.agent.md)
+- [TDD compile prompt](tdd-compile.prompt.md)
+- [Repository audit prompt](repository-audit.prompt.md)
+- all existing `.github/skills/*/SKILL.md` files relevant to testing.
+
+Do not re-interpret the six raw thought documents unless the synthesis explicitly
+identifies an unresolved question requiring source inspection.
+
+## Audit questions
+
+### Current TDD agents
+
+Determine:
+
+- whether `TDDDriver` and `TestingSpecialist` are sufficiently PoKeys/C/HAL-specific;
+- which TypeScript, JWT, REST, database, browser, Java, Jest, Cypress, and generic
+  coverage examples must be removed;
+- whether both agents have distinct responsibilities;
+- whether one agent should be removed, merged, or rewritten;
+- the minimum routing text needed for a future `hil-tdd` skill.
+
+### Current prompts
+
+Determine:
+
+- which prompt files use obsolete or ineffective metadata;
+- which prompts contain generic web-project assumptions;
+- which workflows are duplicated between prompts, agents, instructions, and skills;
+- whether `tdd-compile.prompt.md` should be rewritten, split, or replaced;
+- whether `repository-audit.prompt.md` should remain available for this repository.
+
+### Instructions versus skills
+
+Apply this rule:
+
+- instructions contain short mandatory invariants;
+- skills contain detailed repeatable procedures;
+- prompts initiate a specific workflow;
+- agents define role and available tools;
+- documentation contains rationale, evidence, fixture facts, and decisions.
+
+Prevent the HIL procedure from being copied into all five layers.
+
+### HIL readiness
+
+Determine the minimum infrastructure needed before hardware work:
+
+- canonical synthesis/decision document;
+- versioned fixture schema design;
+- short future HIL instruction;
+- future HIL-TDD skill;
+- status/evidence vocabulary;
+- test-layer taxonomy;
+- agent routing;
+- validation mechanism.
+
+Do not create the fixture, HIL skill, tests, HAL files, or workflow in this plan's
+first corrective PR unless the approved synthesis explicitly requires them.
+
+## Required output
+
+### 1. Findings
+
+List findings by severity:
+
+- P0: invalid or misleading active customization;
+- P1: excessive/generic context or contradictory ownership;
+- P2: missing infrastructure needed before HIL;
+- deferred: actual HIL implementation.
+
+### 2. Target architecture
+
+Provide one target tree showing:
+
+- instructions;
+- prompts;
+- skills;
+- agents;
+- canonical documentation;
+- future HIL fixture and test locations.
+
+For each file state its single responsibility.
+
+### 3. File-by-file disposition
+
+Use:
+
+| Current file | Keep | Rewrite | Split | Archive | Delete | Target size | Reason |
+|---|---:|---:|---:|---:|---:|---:|---|
+
+### 4. Context budgets
+
+Set explicit preferred and maximum line budgets for:
+
+- `TDDDriver`;
+- `TestingSpecialist`;
+- TDD prompt;
+- HIL routing additions;
+- future HIL instruction;
+- future HIL skill.
+
+Measure duplication, not only raw lines.
+
+### 5. Phased PR plan
+
+Prepare small reviewable PRs.
+
+Recommended separation:
+
+1. current TDD-agent and prompt cleanup;
+2. canonical HIL/TDD decision documentation and source archival;
+3. HIL contract/schema infrastructure;
+4. first primitive HIL tests.
+
+Each PR must include:
+
+- exact scope;
+- files changed;
+- acceptance criteria;
+- verification commands;
+- explicit out-of-scope items.
+
+### 6. Decision gates
+
+State what must be manually approved before moving to the next phase.
+
+### 7. Prohibitions
+
+The plan must not:
+
+- operate hardware;
+- assume Pin 52/54 resolution;
+- implement emergency or motion HIL;
+- create a broad one-PR rewrite;
+- duplicate detailed workflows across agents, prompts, instructions, and skills;
+- claim HIL readiness from documentation alone.

--- a/.github/skills/hil-tdd/SKILL.md
+++ b/.github/skills/hil-tdd/SKILL.md
@@ -1,0 +1,369 @@
+---
+name: hil-tdd
+description: >
+  Run Red-Green-Refactor development against a registered PoKeys hardware-in-the-loop
+  fixture. Use for changes whose acceptance criteria depend on real PoKeys hardware,
+  firmware, HAL pin propagation, PEv2 behavior, electrical loopbacks, or measured timing.
+---
+
+# HIL-TDD Skill
+
+## When to use
+
+Use this skill when the acceptance criterion for a behavior requires:
+
+- real PoKeys57E digital I/O (not a mock or simulator);
+- firmware-level PEv2 switch mapping (LimitN, Home, emergency);
+- physical loopback electrical verification;
+- PWM/ADC analog path confirmation;
+- async update latency with real USB/Ethernet round-trips;
+- RT-cycle timing measurement against a defined threshold.
+
+Do not use HIL as a substitute for unit tests. Unit tests must exist first.
+
+---
+
+## Step A — Classify the requirement
+
+Determine which test layers apply:
+
+1. Unit test — parser, mailbox, HAL export, inversion logic (always required)
+2. Protocol test — async send/parse/retry coverage (always required)
+3. HAL smoke — `halcompile`/`halrun`, exported pins visible
+4. Primitive HIL — real board I/O, minimal HAL config, no machine stack
+5. Machine integration — full `DM542_XXYZ_mill` config, homing, `wcomp`
+6. RT validation — timing measured in RT environment with documented threshold
+
+HIL (layer 4) does not replace layers 1–3.
+
+---
+
+## Step B — Select the fixture
+
+Specify the setup ID explicitly:
+
+```text
+pokeys57e-loopback-v1
+```
+
+Verify before proceeding:
+
+- device model matches setup definition
+- device ID (expected: `27295`) matches
+- fixture revision matches
+- firmware version is compatible
+- declared capability covers the test's requirement
+- required HAL pin names are present in the setup definition
+
+The setup definition is at:
+`tests/hil/setups/pokeys57e-loopback-v1.yaml`
+
+---
+
+## Step C — Acquire and preflight
+
+Before touching any output:
+
+1. Acquire exclusive fixture lock (prevent parallel test runs).
+2. Verify the expected PoKeys device is reachable.
+3. Confirm no production machine or actuators are attached.
+4. Drive all outputs to their safe state (false/inactive).
+5. Read back and confirm all outputs are in the safe state.
+6. Verify that every HAL pin name required by the test exists.
+7. Reject the run if device identity or wiring self-check fails.
+
+A failed preflight is `SKIPPED/NOT RUN`, never `FAIL` and never `PASS`.
+
+---
+
+## Step D — Red phase (HIL-assisted TDD)
+
+For hardware-dependent behavior:
+
+1. Run a narrow HIL probe to observe real board behavior.
+2. Record the observation in `docs/testing/pokeys57e-hil-observations.md` with an observation ID.
+3. Write a failing unit test using that observed contract as the oracle.
+4. Write a failing HIL contract test.
+5. Confirm the unit test fails for the target reason, not infrastructure absence.
+
+A missing device, failed preflight, or setup mismatch is not a red test — it is an
+unavailable test environment.
+
+### HIL-derived unit test oracle comment format
+
+```c
+/* Oracle: HIL-P57E-DIO-001, observed on PoKeys57E DEVICE_ID=27295 */
+```
+
+### Unit test oracle requirements
+
+Unit tests for hardware-facing behavior must cite an oracle from one of:
+
+- official PoKeys/PoLabs protocol specification or manual
+- current upstream `pokeyslib` behavior
+- existing verified LinuxCNC machine configuration
+- a recorded HIL observation (preferred for pin mapping, polarity, PEv2 semantics)
+
+Do not invent expected values from developer assumption.
+
+---
+
+## Step E — Green phase
+
+Implement the smallest production change.
+
+Then run in order:
+
+1. Narrow unit/protocol test suite.
+2. `halcompile` + `halrun` smoke test.
+3. Relevant HIL primitive test case.
+
+Do not run the full machine integration config until the primitive HIL test passes.
+
+---
+
+## Step F — Refactor
+
+Keep all three layers green: unit tests, HAL smoke, HIL primitive.
+
+---
+
+## Step G — Cleanup
+
+Whether the test passes, fails, or is interrupted:
+
+1. Drive all source outputs to their safe state (false/inactive).
+2. Disable any PEv2 operations started by the test.
+3. Unload test HAL components (`halcmd unload all`).
+4. Release the fixture lock.
+5. Report whether cleanup succeeded.
+
+A test that leaves outputs active is a defect in the test itself.
+
+---
+
+## Step H — Evidence
+
+Every HIL run must record:
+
+```text
+commit SHA
+setup ID and revision
+device model and device ID
+firmware version
+LinuxCNC version
+kernel / RT mode
+HAL configuration and hash
+test command
+test result (PASS / FAIL / SKIP and reason)
+observed input/output transitions
+cleanup result
+```
+
+Use `HIL-verified` only when the named setup and test actually ran to completion.
+`HIL-verified` does not imply RT-validated or timing-validated.
+
+---
+
+## Test layer structure
+
+```text
+tests/hil/basic/          — primitive fixture tests (no machine stack)
+  hal/                    — minimal HAL files for each test category
+  pytest/                 — pytest test cases
+  README.md               — scope and boundary contract
+
+tests/integration/linuxcnc/   — machine-integration tests
+  DM542_XXYZ_mill/            — full INI/HAL stack, wcomp switches, homing
+  pytest/
+  README.md
+```
+
+---
+
+## HIL test sequence — primitive fixture
+
+Tests must execute in this order. Each builds on the previous.
+
+### HIL-000 — Identity and HAL export
+
+Goal: prove the runner is connected to the expected device and all required pins exist.
+
+- Load a minimal HAL config (not the full machine INI).
+- Confirm `pokeys.0` component is loaded.
+- Confirm expected device ID is reported.
+- Confirm all HAL pins required by the declared loopback pairs are present.
+- Unload cleanly.
+
+A HAL pin name mismatch here invalidates all subsequent tests.
+
+### HIL-010 — Direct digital loopback
+
+For each declared loopback pair (e.g., Pin 23 → Pin 28):
+
+```text
+set output inactive
+wait until matching input is inactive
+set output active
+wait until matching input is active
+set output inactive
+wait until matching input is inactive
+```
+
+Test raw digital input state first. Test PEv2 logical input (LimitN/Home) separately,
+because the INI enables inversion for several inputs.
+
+Catches: wrong HAL pin number, wrong PinFunction, wrong output write command,
+wrong input parser, wrong PEv2 switch mapping, wrong inversion, async starvation.
+
+### HIL-020 — PWM/ADC loopback
+
+Requires RC low-pass filter at each connection (4.7 kΩ + 1 µF recommended).
+Without the filter, the ADC sees an unstable square wave.
+
+For each PWM/adcout → analog input pair:
+
+```text
+set adcout enable true
+set value to low
+wait for ADC to settle near low
+set value to mid
+wait for ADC to settle near mid
+set value to high
+wait for ADC to settle near high
+restore to safe value
+```
+
+Assertions must be tolerant (monotonic, within ±10% tolerance, not exact).
+Do not load spindle scaling here — that belongs in integration.
+
+### HIL-030 — Pulse engine to fast encoder
+
+Test the PE → encoder path without LinuxCNC `motmod`:
+
+```text
+enable bounded pulse output
+command small positive pulse count
+confirm fast encoder count increases
+command reverse pulse count
+confirm fast encoder count decreases (or changes as expected per direction)
+disable pulse output
+```
+
+Do not wire `joint.N.motor-pos-cmd` here. Joint wiring belongs in integration.
+
+### HIL-040 — Emergency loopback
+
+**Status: EXCLUDED from v1 scope** pending resolution of hardware questions HW-1 and
+HW-2 (Pin 33 → Pin 52 wiring vs `PEv2_EmergencyInputPin=54` in INI). Do not
+implement until the discrepancy is physically confirmed.
+
+When unblocked:
+```text
+set emergency output inactive
+verify emergency input safe/inactive
+set emergency output active
+verify emergency input active
+restore inactive state
+```
+
+---
+
+## PIN NUMBERING INVARIANT
+
+Physical pin N on PoKeys57E = HAL channel index N−1.
+
+Examples confirmed from `Pokeys57E_SimPins.hal`:
+- Physical Pin 23 → `pokeys.0.digout.22.out`
+- Physical Pin 12 → `pokeys.0.digout.11.out`
+
+The fixture YAML stores physical pin numbers and HAL channel indices separately.
+Never treat them as identical.
+
+---
+
+## Declared loopback pairs (v1 fixture)
+
+| Function | Physical output | Physical input | HAL output | Expected logical input |
+|---|---|---|---|---|
+| X min | 23 | 28 | `pokeys.0.digout.22.out` | `pokeys.0.PEv2.0.digin.LimitN.in` |
+| X home | 24 | 29 | `pokeys.0.digout.23.out` | `pokeys.0.PEv2.0.digin.Home.in` |
+| X2 min | 25 | 30 | `pokeys.0.digout.24.out` | `pokeys.0.PEv2.6.digin.LimitN.in` |
+| X2 home | 26 | 31 | `pokeys.0.digout.25.out` | `pokeys.0.PEv2.6.digin.Home.in` |
+| Y min | 12 | 37 | `pokeys.0.digout.11.out` | `pokeys.0.PEv2.1.digin.LimitN.in` |
+| Y home | 13 | 38 | `pokeys.0.digout.12.out` | `pokeys.0.PEv2.1.digin.Home.in` |
+| Z min | 14 | 39 | `pokeys.0.digout.13.out` | `pokeys.0.PEv2.2.digin.LimitN.in` |
+| Z home | 15 | 40 | `pokeys.0.digout.14.out` | `pokeys.0.PEv2.2.digin.Home.in` |
+| PWM/ADC | 17–20 | 41–44 | `pokeys.0.adcout.N.value` | `pokeys.0.adcin.N.val` |
+| Emergency | 33 | 52 | PEv2 emergency out | PEv2 emergency in | ← EXCLUDED (HW-1/HW-2 open) |
+
+Source: `Pokeys57E_SimPins.hal` (provenance); physical continuity not independently
+confirmed. Do not treat switch-label comments (X min/home) as proof of INI enable
+state — the current INI disables positive limits; only limit-minus and home are active.
+
+---
+
+## Reserved pins — do not use in HIL tests
+
+```text
+9   PE external DATA (OC16-CNC)
+11  PE external CLOCK (OC16-CNC)
+51  PE external LATCH (OC16-CNC)
+52  PE emergency input (EXCLUDED — see HW-1/HW-2)
+53  PE charge pump output
+```
+
+Pins 38–40 (integrated PE direction outputs) are available only when PEv2 is
+switched from external generator (OC16-CNC) to integrated generator. Do not
+reassign generator type within a primitive HIL test.
+
+---
+
+## CI workflow
+
+HIL tests must run only on self-hosted runners with the physical fixture.
+
+```yaml
+name: PoKeys57E HIL
+
+on:
+  workflow_dispatch:
+    inputs:
+      device_id:
+        description: "PoKeys device ID"
+        required: true
+        default: "27295"
+
+jobs:
+  hil:
+    runs-on: [self-hosted, linuxcnc, pokeys57e-hil]
+    env:
+      POKEYS_HIL: "1"
+      POKEYS_DEVICE_ID: ${{ inputs.device_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: sudo make -f Makefile.noqmake install
+      - name: Run HIL tests
+        run: pytest -m hil tests/hil/basic --junitxml=hil-results.xml
+      - name: Stop HAL safely
+        if: always()
+        run: |
+          halcmd stop || true
+          halcmd unload all || true
+```
+
+Do not run this workflow on normal GitHub-hosted CI.
+
+---
+
+## Status vocabulary for PR evidence
+
+```text
+Unit-tested:        yes / no
+HAL-smoke-tested:   yes / no
+HIL-tested:         yes / no  (requires physical fixture run)
+RT-validated:       yes / no  (requires measured timing)
+```
+
+Do not mark `HIL-tested: yes` based on a userspace simulation or code review.

--- a/.github/skills/hil-tdd/SKILL.md
+++ b/.github/skills/hil-tdd/SKILL.md
@@ -47,7 +47,8 @@ Before proceeding, read the fixture YAML at
 
 - `runnable: true` — if not, stop; the fixture is not verified for use
 - `fixture_status: verified` — if draft, stop; hardware questions are unresolved
-- device model, `expected_device_id`, and fixture `revision` match
+- device model and fixture `revision` match
+- when the fixture is verified and `expected_device_id` is set, the device ID must match
 - firmware version is compatible
 - the required capability is listed (not merely declared as draft)
 - required HAL pin names are present in the setup definition
@@ -176,7 +177,7 @@ LinuxCNC version
 kernel / RT mode
 HAL configuration used
 test command
-test result (PASS / FAIL / SKIP / ERROR and reason)
+test result (PASS / FAIL / SKIPPED / ERROR and reason)
 observed input/output transitions
 cleanup result
 ```
@@ -234,12 +235,13 @@ See `tests/hil/setups/pokeys57e-loopback-v1.md` for wiring constraints.
 ## PR evidence checklist
 
 ```
-Unit-tested:       yes / no
-HAL-smoke-tested:  yes / no
-HIL-tested:        yes / no  (requires physical fixture run against verified fixture)
-RT-validated:      yes / no  (requires measured timing in RT environment)
-Timing-validated:  yes / no  (requires measured threshold and tolerance)
+Unit-tested:         yes / no
+HAL-smoke-tested:    yes / no
+HIL-test-executed:   yes / no  (requires physical fixture run against a verified fixture)
+HIL-verified:        yes / no  (requires the named HIL test to pass on the named fixture revision)
+RT-validated:        yes / no  (requires measured timing in RT environment)
+Timing-validated:    yes / no  (requires measured threshold and tolerance)
 ```
 
 See `references/result-schema.md` for precise status term definitions.
-Do not mark `HIL-tested: yes` based on a userspace simulation or code review.
+Do not mark `HIL-verified: yes` based on a userspace simulation or code review.

--- a/.github/skills/hil-tdd/SKILL.md
+++ b/.github/skills/hil-tdd/SKILL.md
@@ -54,6 +54,7 @@ Before proceeding, read the fixture YAML at
 - firmware version is compatible
 - the required capability is listed (not merely declared as draft)
 - required HAL pin names are present in the setup definition
+- all verification fields required by the selected capability are `true`
 
 For the current physical-pin layout and capability constraints, see
 `tests/hil/setups/pokeys57e-loopback-v1.md`.

--- a/.github/skills/hil-tdd/SKILL.md
+++ b/.github/skills/hil-tdd/SKILL.md
@@ -16,7 +16,8 @@ Use this skill when the acceptance criterion requires:
 - physical loopback electrical verification;
 - PWM/ADC analog path confirmation;
 - async update latency with real USB/Ethernet round-trips;
-- RT-cycle timing measurement against a defined threshold.
+- RT environment validation in LinuxCNC;
+- timing validation against a defined threshold and tolerance.
 
 Do not use HIL as a substitute for unit tests.
 
@@ -31,7 +32,8 @@ Determine which test layers apply:
 3. HAL smoke — `halcompile`/`halrun`, exported pins visible
 4. Primitive HIL — real board I/O, minimal HAL config, no machine stack
 5. Machine integration — full `DM542_XXYZ_mill`, `wcomp`, homing, joint wiring
-6. RT validation — timing measured in RT environment with documented threshold
+6. RT environment validation — execute the behavior in the applicable LinuxCNC RT environment
+7. Timing validation — measure timing against a documented threshold and tolerance
 
 HIL (layer 4) does not replace layers 1–3. Layers 1–2 are required where
 mechanically applicable; a documentation-only change does not need an invented unit test.
@@ -75,12 +77,11 @@ Before touching any output:
 
 | Condition | Result |
 |---|---|
-| `POKEYS_HIL` not set | SKIPPED |
-| Non-HIL runner | SKIPPED |
-| `runnable: false` or `fixture_status: draft` | ERROR |
-| HIL requested but device absent | ERROR |
-| Device identity mismatch | ERROR |
-| Fixture revision mismatch | ERROR |
+| `POKEYS_HIL` absent | SKIPPED |
+| Test suite discovered on a non-HIL runner without HIL being requested | SKIPPED |
+| `POKEYS_HIL=1`, but runner lacks the fixture | ERROR |
+| Fixture draft or not runnable | ERROR |
+| Device missing or mismatched during requested HIL run | ERROR |
 | Continuity/self-test fails | ERROR |
 | Behavior differs from expectation | FAIL |
 | Success | PASS |
@@ -126,7 +127,7 @@ a prior expectation is valid for discovery; it must not be reported as a test re
 ### Oracle comment format
 
 ```c
-/* Oracle: HIL-P57E-DIO-001, observed on PoKeys57E DEVICE_ID=27295 */
+/* Oracle: HIL-P57E-DIO-001, setup=pokeys57e-loopback-v1 rev=1, device=<verified-id> */
 ```
 
 ---
@@ -239,8 +240,8 @@ Unit-tested:         yes / no
 HAL-smoke-tested:    yes / no
 HIL-test-executed:   yes / no  (requires physical fixture run against a verified fixture)
 HIL-verified:        yes / no  (requires the named HIL test to pass on the named fixture revision)
-RT-validated:        yes / no  (requires measured timing in RT environment)
-Timing-validated:    yes / no  (requires measured threshold and tolerance)
+RT-validated:        yes / no  (behavior executed in the applicable RT environment)
+Timing-validated:    yes / no  (timing measured against a threshold)
 ```
 
 See `references/result-schema.md` for precise status term definitions.

--- a/.github/skills/hil-tdd/SKILL.md
+++ b/.github/skills/hil-tdd/SKILL.md
@@ -57,7 +57,8 @@ Before proceeding, read the fixture YAML at
 - all verification fields required by the selected capability are `true`
 
 For the current physical-pin layout and capability constraints, see
-`tests/hil/setups/pokeys57e-loopback-v1.md`.
+`tests/hil/setups/pokeys57e-loopback-v1.md`. Treat the historical external
+configuration references there as provenance only; they do not verify the live fixture.
 
 ---
 

--- a/.github/skills/hil-tdd/SKILL.md
+++ b/.github/skills/hil-tdd/SKILL.md
@@ -10,8 +10,7 @@ description: >
 
 ## When to use
 
-Use this skill when the acceptance criterion for a behavior requires:
-
+Use this skill when the acceptance criterion requires:
 - real PoKeys57E digital I/O (not a mock or simulator);
 - firmware-level PEv2 switch mapping (LimitN, Home, emergency);
 - physical loopback electrical verification;
@@ -19,7 +18,7 @@ Use this skill when the acceptance criterion for a behavior requires:
 - async update latency with real USB/Ethernet round-trips;
 - RT-cycle timing measurement against a defined threshold.
 
-Do not use HIL as a substitute for unit tests. Unit tests must exist first.
+Do not use HIL as a substitute for unit tests.
 
 ---
 
@@ -27,36 +26,34 @@ Do not use HIL as a substitute for unit tests. Unit tests must exist first.
 
 Determine which test layers apply:
 
-1. Unit test — parser, mailbox, HAL export, inversion logic (always required)
-2. Protocol test — async send/parse/retry coverage (always required)
+1. Unit test — parser, mailbox, HAL export, inversion logic
+2. Protocol test — async send/parse/retry coverage
 3. HAL smoke — `halcompile`/`halrun`, exported pins visible
 4. Primitive HIL — real board I/O, minimal HAL config, no machine stack
-5. Machine integration — full `DM542_XXYZ_mill` config, homing, `wcomp`
+5. Machine integration — full `DM542_XXYZ_mill`, `wcomp`, homing, joint wiring
 6. RT validation — timing measured in RT environment with documented threshold
 
-HIL (layer 4) does not replace layers 1–3.
+HIL (layer 4) does not replace layers 1–3. Layers 1–2 are required where
+mechanically applicable; a documentation-only change does not need an invented unit test.
 
 ---
 
 ## Step B — Select the fixture
 
-Specify the setup ID explicitly:
+Specify the setup ID: `pokeys57e-loopback-v1`
 
-```text
-pokeys57e-loopback-v1
-```
+Before proceeding, read the fixture YAML at
+`tests/hil/setups/pokeys57e-loopback-v1.yaml` and verify:
 
-Verify before proceeding:
-
-- device model matches setup definition
-- device ID (expected: `27295`) matches
-- fixture revision matches
+- `runnable: true` — if not, stop; the fixture is not verified for use
+- `fixture_status: verified` — if draft, stop; hardware questions are unresolved
+- device model, `expected_device_id`, and fixture `revision` match
 - firmware version is compatible
-- declared capability covers the test's requirement
+- the required capability is listed (not merely declared as draft)
 - required HAL pin names are present in the setup definition
 
-The setup definition is at:
-`tests/hil/setups/pokeys57e-loopback-v1.yaml`
+For the current physical-pin layout and capability constraints, see
+`tests/hil/setups/pokeys57e-loopback-v1.md`.
 
 ---
 
@@ -64,59 +61,82 @@ The setup definition is at:
 
 Before touching any output:
 
-1. Acquire exclusive fixture lock (prevent parallel test runs).
-2. Verify the expected PoKeys device is reachable.
+1. Acquire exclusive fixture lock (prevent parallel runs).
+2. Verify expected PoKeys device is reachable and identity matches.
 3. Confirm no production machine or actuators are attached.
-4. Drive all outputs to their safe state (false/inactive).
-5. Read back and confirm all outputs are in the safe state.
-6. Verify that every HAL pin name required by the test exists.
-7. Reject the run if device identity or wiring self-check fails.
+4. Configure all source channels to `startup_mode` (high impedance if specified).
+5. Configure sink endpoints as `required_mode_before_source_enable`.
+6. Apply `safe_logical_value` to all source channels.
+7. Read back and verify all source channels report the expected safe physical level.
+8. Verify all required HAL pin names exist.
 
-A failed preflight is `SKIPPED/NOT RUN`, never `FAIL` and never `PASS`.
+### Preflight outcomes
+
+| Condition | Result |
+|---|---|
+| `POKEYS_HIL` not set | SKIPPED |
+| Non-HIL runner | SKIPPED |
+| `runnable: false` or `fixture_status: draft` | ERROR |
+| HIL requested but device absent | ERROR |
+| Device identity mismatch | ERROR |
+| Fixture revision mismatch | ERROR |
+| Continuity/self-test fails | ERROR |
+| Behavior differs from expectation | FAIL |
+| Success | PASS |
+
+A required HIL job that produces zero test results must not be green.
 
 ---
 
-## Step D — Red phase (HIL-assisted TDD)
+## Step D — Red phase
 
-For hardware-dependent behavior:
+Two distinct workflows apply depending on whether the behavior is already
+specified or must be discovered from hardware.
 
-1. Run a narrow HIL probe to observe real board behavior.
-2. Record the observation in `docs/testing/pokeys57e-hil-observations.md` with an observation ID.
-3. Write a failing unit test using that observed contract as the oracle.
-4. Write a failing HIL contract test.
-5. Confirm the unit test fails for the target reason, not infrastructure absence.
+### Workflow A — Specification-known behavior
 
-A missing device, failed preflight, or setup mismatch is not a red test — it is an
-unavailable test environment.
+Use when the expected behavior is documented in the PoKeys protocol spec,
+upstream `pokeyslib`, or a verified existing configuration:
 
-### HIL-derived unit test oracle comment format
+```
+authoritative specification or existing verified HIL observation
+→ failing unit test (oracle cited in comment)
+→ implementation
+→ unit test passes
+→ HIL confirmation run
+```
+
+### Workflow B — Hardware behavior not yet known
+
+Use when the expected behavior must be observed before a test can be written:
+
+```
+narrow exploratory HIL probe (not a Red test — record observation only)
+→ observation recorded in docs/testing/pokeys57e-hil-observations.md
+→ failing deterministic unit test (observation as oracle)
+→ implementation
+→ unit test passes
+→ automated HIL regression test
+```
+
+The exploratory observation is not itself the Red test. Running a probe without
+a prior expectation is valid for discovery; it must not be reported as a test result.
+
+### Oracle comment format
 
 ```c
 /* Oracle: HIL-P57E-DIO-001, observed on PoKeys57E DEVICE_ID=27295 */
 ```
 
-### Unit test oracle requirements
-
-Unit tests for hardware-facing behavior must cite an oracle from one of:
-
-- official PoKeys/PoLabs protocol specification or manual
-- current upstream `pokeyslib` behavior
-- existing verified LinuxCNC machine configuration
-- a recorded HIL observation (preferred for pin mapping, polarity, PEv2 semantics)
-
-Do not invent expected values from developer assumption.
-
 ---
 
 ## Step E — Green phase
 
-Implement the smallest production change.
-
-Then run in order:
+Implement the smallest production change. Then run in order:
 
 1. Narrow unit/protocol test suite.
 2. `halcompile` + `halrun` smoke test.
-3. Relevant HIL primitive test case.
+3. Relevant primitive HIL test case.
 
 Do not run the full machine integration config until the primitive HIL test passes.
 
@@ -132,13 +152,14 @@ Keep all three layers green: unit tests, HAL smoke, HIL primitive.
 
 Whether the test passes, fails, or is interrupted:
 
-1. Drive all source outputs to their safe state (false/inactive).
-2. Disable any PEv2 operations started by the test.
-3. Unload test HAL components (`halcmd unload all`).
-4. Release the fixture lock.
-5. Report whether cleanup succeeded.
+1. Apply `safe_logical_value` to all source channels.
+2. Configure all sources back to `startup_mode` (high impedance).
+3. Disable any PEv2 operations started by the test.
+4. Unload test HAL components (`halcmd unload all`).
+5. Release the fixture lock.
+6. Report whether cleanup succeeded.
 
-A test that leaves outputs active is a defect in the test itself.
+A test that leaves any output in a non-safe state is a defect in the test.
 
 ---
 
@@ -146,224 +167,79 @@ A test that leaves outputs active is a defect in the test itself.
 
 Every HIL run must record:
 
-```text
+```
 commit SHA
 setup ID and revision
-device model and device ID
+device model and expected_device_id
 firmware version
 LinuxCNC version
 kernel / RT mode
-HAL configuration and hash
+HAL configuration used
 test command
-test result (PASS / FAIL / SKIP and reason)
+test result (PASS / FAIL / SKIP / ERROR and reason)
 observed input/output transitions
 cleanup result
 ```
 
-Use `HIL-verified` only when the named setup and test actually ran to completion.
-`HIL-verified` does not imply RT-validated or timing-validated.
-
----
-
-## Test layer structure
-
-```text
-tests/hil/basic/          — primitive fixture tests (no machine stack)
-  hal/                    — minimal HAL files for each test category
-  pytest/                 — pytest test cases
-  README.md               — scope and boundary contract
-
-tests/integration/linuxcnc/   — machine-integration tests
-  DM542_XXYZ_mill/            — full INI/HAL stack, wcomp switches, homing
-  pytest/
-  README.md
-```
+See `references/result-schema.md` for the full status vocabulary.
 
 ---
 
 ## HIL test sequence — primitive fixture
 
-Tests must execute in this order. Each builds on the previous.
+Tests run in this order; each depends on the previous passing.
 
 ### HIL-000 — Identity and HAL export
 
-Goal: prove the runner is connected to the expected device and all required pins exist.
-
 - Load a minimal HAL config (not the full machine INI).
-- Confirm `pokeys.0` component is loaded.
-- Confirm expected device ID is reported.
-- Confirm all HAL pins required by the declared loopback pairs are present.
+- Confirm device is reachable and `expected_device_id` matches.
+- Confirm all HAL pins required by the declared loopbacks are present.
 - Unload cleanly.
 
 A HAL pin name mismatch here invalidates all subsequent tests.
 
 ### HIL-010 — Direct digital loopback
 
-For each declared loopback pair (e.g., Pin 23 → Pin 28):
+For each loopback pair listed in the fixture YAML:
 
-```text
-set output inactive
-wait until matching input is inactive
-set output active
-wait until matching input is active
-set output inactive
-wait until matching input is inactive
+```
+set source to safe_logical_value
+verify sink reports expected safe state
+set source to active (not safe_logical_value)
+verify sink transitions
+set source back to safe_logical_value
+verify sink returns to safe state
 ```
 
-Test raw digital input state first. Test PEv2 logical input (LimitN/Home) separately,
-because the INI enables inversion for several inputs.
-
-Catches: wrong HAL pin number, wrong PinFunction, wrong output write command,
-wrong input parser, wrong PEv2 switch mapping, wrong inversion, async starvation.
+Test raw digital input and PEv2 logical input (LimitN/Home) separately, because
+the INI enables inversion. Catches: wrong HAL index, wrong PinFunction, wrong
+parser, wrong PEv2 mapping, inversion error, async starvation.
 
 ### HIL-020 — PWM/ADC loopback
 
-Requires RC low-pass filter at each connection (4.7 kΩ + 1 µF recommended).
-Without the filter, the ADC sees an unstable square wave.
-
-For each PWM/adcout → analog input pair:
-
-```text
-set adcout enable true
-set value to low
-wait for ADC to settle near low
-set value to mid
-wait for ADC to settle near mid
-set value to high
-wait for ADC to settle near high
-restore to safe value
-```
-
-Assertions must be tolerant (monotonic, within ±10% tolerance, not exact).
-Do not load spindle scaling here — that belongs in integration.
+Requires RC low-pass filter (4.7 kΩ + 1 µF) at each PWM→ADC connection.
+See `tests/hil/setups/pokeys57e-loopback-v1.md` for wiring constraints.
+**Status**: excluded from v1; RC filter not fitted.
 
 ### HIL-030 — Pulse engine to fast encoder
 
-Test the PE → encoder path without LinuxCNC `motmod`:
-
-```text
-enable bounded pulse output
-command small positive pulse count
-confirm fast encoder count increases
-command reverse pulse count
-confirm fast encoder count decreases (or changes as expected per direction)
-disable pulse output
-```
-
-Do not wire `joint.N.motor-pos-cmd` here. Joint wiring belongs in integration.
+**Status**: excluded from v1; HW-3 (motor-enable conflict) unresolved.
 
 ### HIL-040 — Emergency loopback
 
-**Status: EXCLUDED from v1 scope** pending resolution of hardware questions HW-1 and
-HW-2 (Pin 33 → Pin 52 wiring vs `PEv2_EmergencyInputPin=54` in INI). Do not
-implement until the discrepancy is physically confirmed.
+**Status**: excluded from v1; HW-1/HW-2 (Pin 33/52 vs INI Pin 54) unresolved.
 
-When unblocked:
-```text
-set emergency output inactive
-verify emergency input safe/inactive
-set emergency output active
-verify emergency input active
-restore inactive state
+---
+
+## PR evidence checklist
+
+```
+Unit-tested:       yes / no
+HAL-smoke-tested:  yes / no
+HIL-tested:        yes / no  (requires physical fixture run against verified fixture)
+RT-validated:      yes / no  (requires measured timing in RT environment)
+Timing-validated:  yes / no  (requires measured threshold and tolerance)
 ```
 
----
-
-## PIN NUMBERING INVARIANT
-
-Physical pin N on PoKeys57E = HAL channel index N−1.
-
-Examples confirmed from `Pokeys57E_SimPins.hal`:
-- Physical Pin 23 → `pokeys.0.digout.22.out`
-- Physical Pin 12 → `pokeys.0.digout.11.out`
-
-The fixture YAML stores physical pin numbers and HAL channel indices separately.
-Never treat them as identical.
-
----
-
-## Declared loopback pairs (v1 fixture)
-
-| Function | Physical output | Physical input | HAL output | Expected logical input |
-|---|---|---|---|---|
-| X min | 23 | 28 | `pokeys.0.digout.22.out` | `pokeys.0.PEv2.0.digin.LimitN.in` |
-| X home | 24 | 29 | `pokeys.0.digout.23.out` | `pokeys.0.PEv2.0.digin.Home.in` |
-| X2 min | 25 | 30 | `pokeys.0.digout.24.out` | `pokeys.0.PEv2.6.digin.LimitN.in` |
-| X2 home | 26 | 31 | `pokeys.0.digout.25.out` | `pokeys.0.PEv2.6.digin.Home.in` |
-| Y min | 12 | 37 | `pokeys.0.digout.11.out` | `pokeys.0.PEv2.1.digin.LimitN.in` |
-| Y home | 13 | 38 | `pokeys.0.digout.12.out` | `pokeys.0.PEv2.1.digin.Home.in` |
-| Z min | 14 | 39 | `pokeys.0.digout.13.out` | `pokeys.0.PEv2.2.digin.LimitN.in` |
-| Z home | 15 | 40 | `pokeys.0.digout.14.out` | `pokeys.0.PEv2.2.digin.Home.in` |
-| PWM/ADC | 17–20 | 41–44 | `pokeys.0.adcout.N.value` | `pokeys.0.adcin.N.val` |
-| Emergency | 33 | 52 | PEv2 emergency out | PEv2 emergency in | ← EXCLUDED (HW-1/HW-2 open) |
-
-Source: `Pokeys57E_SimPins.hal` (provenance); physical continuity not independently
-confirmed. Do not treat switch-label comments (X min/home) as proof of INI enable
-state — the current INI disables positive limits; only limit-minus and home are active.
-
----
-
-## Reserved pins — do not use in HIL tests
-
-```text
-9   PE external DATA (OC16-CNC)
-11  PE external CLOCK (OC16-CNC)
-51  PE external LATCH (OC16-CNC)
-52  PE emergency input (EXCLUDED — see HW-1/HW-2)
-53  PE charge pump output
-```
-
-Pins 38–40 (integrated PE direction outputs) are available only when PEv2 is
-switched from external generator (OC16-CNC) to integrated generator. Do not
-reassign generator type within a primitive HIL test.
-
----
-
-## CI workflow
-
-HIL tests must run only on self-hosted runners with the physical fixture.
-
-```yaml
-name: PoKeys57E HIL
-
-on:
-  workflow_dispatch:
-    inputs:
-      device_id:
-        description: "PoKeys device ID"
-        required: true
-        default: "27295"
-
-jobs:
-  hil:
-    runs-on: [self-hosted, linuxcnc, pokeys57e-hil]
-    env:
-      POKEYS_HIL: "1"
-      POKEYS_DEVICE_ID: ${{ inputs.device_id }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build
-        run: sudo make -f Makefile.noqmake install
-      - name: Run HIL tests
-        run: pytest -m hil tests/hil/basic --junitxml=hil-results.xml
-      - name: Stop HAL safely
-        if: always()
-        run: |
-          halcmd stop || true
-          halcmd unload all || true
-```
-
-Do not run this workflow on normal GitHub-hosted CI.
-
----
-
-## Status vocabulary for PR evidence
-
-```text
-Unit-tested:        yes / no
-HAL-smoke-tested:   yes / no
-HIL-tested:         yes / no  (requires physical fixture run)
-RT-validated:       yes / no  (requires measured timing)
-```
-
+See `references/result-schema.md` for precise status term definitions.
 Do not mark `HIL-tested: yes` based on a userspace simulation or code review.

--- a/.github/skills/hil-tdd/references/result-schema.md
+++ b/.github/skills/hil-tdd/references/result-schema.md
@@ -24,8 +24,8 @@ Do not use the legacy status label. Use `HIL-test-executed` (ran) or
 
 | Outcome | Condition |
 |---|---|
-| SKIPPED | `POKEYS_HIL` not set, or non-HIL runner |
-| ERROR | HIL requested but device absent; device identity or revision mismatch; continuity/self-test fails; `runnable: false`; fixture is still `draft`; expected device ID is unresolved or mismatched for a required run |
+| SKIPPED | `POKEYS_HIL` is absent, or the suite is discovered on a non-HIL runner without HIL being requested |
+| ERROR | `POKEYS_HIL=1` but the runner lacks the fixture; fixture is draft or not runnable; identity or revision mismatch; self-test fails |
 | FAIL | Hardware behavior differs from expected |
 | PASS | Test executed successfully |
 

--- a/.github/skills/hil-tdd/references/result-schema.md
+++ b/.github/skills/hil-tdd/references/result-schema.md
@@ -1,0 +1,41 @@
+# HIL Test Result and Status Schema
+
+Single authority for HIL status vocabulary. Referenced by `hil-tdd.instructions.md`
+and `hil-tdd/SKILL.md`. Do not duplicate this table elsewhere.
+
+---
+
+## Status terms
+
+| Term | Meaning |
+|---|---|
+| `HIL-observed` | Exploratory physical observation recorded as oracle evidence. Not a test result. |
+| `HIL-test-executed` | A named HIL test ran to completion, regardless of outcome. |
+| `HIL-verified` | A named HIL test passed on the named fixture at the stated revision. |
+| `RT-validated` | Behavior was tested in the applicable LinuxCNC real-time environment. Do not redefine; the repository engineering contract owns this term. |
+| `Timing-validated` | Timing was measured against a documented threshold with an identified method. |
+
+Do not use `HIL-tested` — its distinction from `HIL-verified` is unclear. Use
+`HIL-test-executed` (ran) or `HIL-verified` (passed) instead.
+
+---
+
+## Test result outcomes
+
+| Outcome | Condition |
+|---|---|
+| SKIPPED | `POKEYS_HIL` not set, or non-HIL runner |
+| ERROR | HIL requested but device absent; device identity or revision mismatch; continuity/self-test fails; `runnable: false` |
+| FAIL | Hardware behavior differs from expected |
+| PASS | Test executed successfully |
+
+A required HIL job that produces zero test results must not be reported as green.
+
+---
+
+## Prohibited claims
+
+- Do not claim `HIL-verified` from a mock, simulator, or userspace-only run.
+- Do not claim `RT-validated` from a userspace test.
+- Do not claim `Timing-validated` without a measured baseline and documented tolerance.
+- Do not claim any status from code review or static analysis.

--- a/.github/skills/hil-tdd/references/result-schema.md
+++ b/.github/skills/hil-tdd/references/result-schema.md
@@ -15,8 +15,8 @@ and `hil-tdd/SKILL.md`. Do not duplicate this table elsewhere.
 | `RT-validated` | Behavior was tested in the applicable LinuxCNC real-time environment. Do not redefine; the repository engineering contract owns this term. |
 | `Timing-validated` | Timing was measured against a documented threshold with an identified method. |
 
-Do not use `HIL-tested` — its distinction from `HIL-verified` is unclear. Use
-`HIL-test-executed` (ran) or `HIL-verified` (passed) instead.
+Do not use the legacy status label. Use `HIL-test-executed` (ran) or
+`HIL-verified` (passed) instead.
 
 ---
 
@@ -25,7 +25,7 @@ Do not use `HIL-tested` — its distinction from `HIL-verified` is unclear. Use
 | Outcome | Condition |
 |---|---|
 | SKIPPED | `POKEYS_HIL` not set, or non-HIL runner |
-| ERROR | HIL requested but device absent; device identity or revision mismatch; continuity/self-test fails; `runnable: false` |
+| ERROR | HIL requested but device absent; device identity or revision mismatch; continuity/self-test fails; `runnable: false`; fixture is still `draft`; expected device ID is unresolved or mismatched for a required run |
 | FAIL | Hardware behavior differs from expected |
 | PASS | Test executed successfully |
 

--- a/docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md
+++ b/docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md
@@ -1,11 +1,11 @@
 # HIL/TDD Guidance Synthesis
 
-**Status**: Approved for documentation/skeleton scope
+**Status**: Proposed for approval in PR #139
 **Date**: 2026-07-30
 **Input documents**: 6 thought documents in `docs/HIL_Setup_4_TDD/`
 **Produces**: authoritative input for `tdd-hil-infrastructure-audit.prompt.md`
 
-**Approval metadata**: this synthesis was accepted as the basis for the initial HIL-TDD infrastructure skeleton in PR #139. No hardware runs were executed in this phase; evidence is limited to fixture definitions, documented constraints, and review-approved guidance.
+**Approval metadata**: this document is proposed as the reviewable synthesis artifact for the HIL-TDD infrastructure skeleton. No hardware runs were executed in this phase; evidence is limited to fixture definitions, documented constraints, and review-approved guidance.
 
 **Conflict and resolution**: earlier drafts conflated primitive HIL with machine integration and used ambiguous status terms. The active guidance now separates those scopes, centralizes status vocabulary in the HIL result schema, and keeps the fixture draft until HW-0 through HW-5 are resolved.
 
@@ -95,26 +95,26 @@ inverted or active-low outputs.
 
 ## 3. Claim Matrix (summary)
 
-| ID | Claim | Classification | Decision |
-|---|---|---|---|
-| C-01 | Physical pin N = HAL index N−1 | Verified (SimPins.hal) | Encode as fixture invariant |
-| C-02 | HIL does not replace unit/protocol tests | Supported | Adopt as rule |
-| C-03 | DM542 config is integration scope | Proposal | Accept (D-02) |
-| C-04 | wcomp is Layer 3 / integration | Proposal | Accept (D-02) |
-| C-05 | Emergency wired Pin 33 → Pin 52 | Provenance | Excluded (D-03) |
-| C-06 | INI `PEv2_EmergencyInputPin=54` | Provenance | Excluded (D-03) |
-| C-07/08 | Instruction file name | Conflict | Resolved: `hil-tdd` (D-01) |
-| C-09 | No dedicated HIL agent | Supported | Adopt (D-04) |
-| C-10 | AxisEnableOutputPins_N=1 conflicts FastEncoder1A | Proposal | Deferred (HW-3) |
-| C-11 | PWM→ADC needs RC filter | Supported | Documented constraint |
-| C-12 | `HIL-observed` status category | Proposal | Accept (D-06) |
-| C-13 | `applyTo: tests/hil/**` only | Proposal | Accept (D-07) |
-| C-14 | Agent routing hooks only | Supported | Adopt |
-| C-15 | First PR: documentation and skeleton only | Supported | Adopt |
-| C-16 | Loopback pairs from SimPins.hal | Provenance | Unconfirmed; mark as such |
-| C-17 | Pins 9, 11, 51 reserved for OC16-CNC | Supported | Encode in YAML |
-| C-18 | PWM pins 17–22, ADC pins 41–47 | Supported | Encode in fixture MD |
-| C-19/20 | Separate hil/basic and hil/machine dirs | Proposal | Accept (D-05) |
+| ID | Claim | Source | Classification | Evidence | Conflict / required resolution |
+|---|---|---|---|---|---|
+| C-01 | Physical pin N = HAL index N−1 | Historical HAL convention + current export implementation | Supported, but not yet physically verified | Existing HAL export and fixture naming convention | Treat as a fixture convention pending physical confirmation |
+| C-02 | HIL does not replace unit/protocol tests | Guidance synthesis and engineering contract | Supported | Existing instruction and skill scope | No conflict; retain as rule |
+| C-03 | DM542 config is integration scope | Guidance synthesis | Supported | Primitive-vs-integration split | No conflict; keep in machine integration tree |
+| C-04 | `wcomp` is integration scope | Guidance synthesis | Supported | Machine integration guidance | No conflict; keep out of primitive HIL |
+| C-05 | Emergency loopback is Pin 33 → Pin 52 | Historical external configuration + INI | Unresolved | Conflicting references in the external config and INI | Resolve via fixture hardware review before enabling |
+| C-06 | `PEv2_EmergencyInputPin=54` | INI provenance | Unresolved | Conflict with historical wiring reference | Resolve via fixture hardware review before enabling |
+| C-07/08 | Instruction file name | Guidance synthesis | Supported | Naming convention and skill name | No conflict; use `hil-tdd.instructions.md` |
+| C-09 | No dedicated HIL agent | Guidance synthesis | Supported | Current routing hooks only | No conflict; keep routing hooks only |
+| C-10 | Axis enable output pins conflict with FastEncoder1A | Hardware constraint note | Deferred | Hardware question HW-3 | Resolve before PE/encoder tests |
+| C-11 | PWM→ADC needs RC filter | Fixture documentation | Supported | Hardware constraint documented in v1 scope | Keep out of v1 until hardware fitted |
+| C-12 | `HIL-observed` status category | Guidance synthesis | Supported | Result schema and observation log | No conflict; keep the status term |
+| C-13 | `applyTo: tests/hil/**` only | Guidance synthesis | Supported | Instruction scope contract | No conflict; keep scope narrow |
+| C-14 | Agent routing hooks only | Guidance synthesis | Supported | Current agent routing | No conflict; no extra HIL agent yet |
+| C-15 | First PR is documentation and skeleton only | Issue #138 acceptance criteria | Supported | Current PR scope and draft fixture status | No conflict; keep hardware work deferred |
+| C-16 | Loopback pairs are provenance-only until verified | Fixture YAML and Markdown | Supported | Draft fixture status and HW-4/HW-5 | Keep unconfirmed until continuity/polarity checks |
+| C-17 | Pins 9, 11, 51 reserved for OC16-CNC | Fixture YAML | Supported | Reserved pin list | No conflict; preserve in fixture |
+| C-18 | PWM pins 17–22, ADC pins 41–47 | Fixture documentation | Supported | Capability matrix | Keep as planned future scope |
+| C-19/20 | Separate primitive and machine-test directories | Guidance synthesis | Supported | Directory split and scope contract | No conflict; preserve split |
 
 ---
 

--- a/docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md
+++ b/docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md
@@ -1,0 +1,161 @@
+# HIL/TDD Guidance Synthesis
+
+**Status**: Approved  
+**Date**: 2026-07-30  
+**Input documents**: 6 thought documents in `docs/HIL_Setup_4_TDD/`  
+**Produces**: authoritative input for `tdd-hil-infrastructure-audit.prompt.md`
+
+---
+
+## 1. Source Inventory
+
+| File | Type | Unique contribution | Notes |
+|---|---|---|---|
+| `HIL_TDD_guidance_suggestion1.md` | Proposal | 4-layer HIL architecture; `hil-tdd` skill; `hil-tests.instructions.md` name | Superseded on instruction name |
+| `HIL_moduletests_thoughts.md` | **Exact duplicate** of suggestion1 | None | Delete; adds no independent evidence |
+| `PoKeys57E pin modes.md` | Evidence + proposals | Pin capability table, OC16-CNC reservation, PWM/ADC constraints, motor-enable conflict | Unique; keep as fixture reference |
+| `TDD Guidance for PokeysHal1.md` | Proposal | HIL-as-oracle model; `HIL-observed` status; observation ID format | Unique; merge into skill |
+| `TDD Guidance for PokeysHal2.md` | Proposal | Hard primitive-HIL / machine-integration separation; test-layer table | Unique; merge into skill |
+| `TDD_HILguidance_thoughts.md` | Proposal + draft | Full instruction draft; CI workflow YAML; complete test sequence | Primary draft source |
+
+`HIL_moduletests_thoughts.md` is a content duplicate of `HIL_TDD_guidance_suggestion1.md`. Count once.
+
+---
+
+## 2. Accepted Decisions
+
+### D-01 — Instruction file name: `hil-tdd.instructions.md`
+
+Use `hil-tdd.instructions.md`. Consistent with skill name `hil-tdd` and naming
+conventions of other skills (`convert-to-hal-rtapi`). Supersedes `hil-tests`
+proposed by suggestion1/moduletests.
+
+### D-02 — `wcomp` and `DM542_XXYZ_mill` are integration scope
+
+Primitive HIL (`tests/hil/basic/`) must not load `wcomp`, kinematics, `motmod`,
+or the `DM542_XXYZ_mill` stack. These belong in `tests/hil/machine/linuxcnc/`.
+
+A failure in primitive HIL must point to one driver subsystem. Loading the full
+machine stack makes failures ambiguous across driver, HAL naming, INI, homing,
+and wiring.
+
+### D-03 — Emergency loopback excluded from v1
+
+The emergency loopback (Pin 33 → Pin 52) is excluded until HW-1 and HW-2 are
+resolved. `Pokeys57E_SimPins.hal` comments say Pin 52; the INI says
+`PEv2_EmergencyInputPin=54`. These are conflicting provenance, not verified facts.
+
+### D-04 — No dedicated HIL agent at this time
+
+`TDDDriver` and `TestingSpecialist` receive routing hooks only. A dedicated
+`HILTestOperator` agent is justified only when the fixture gains SSH access to
+a dedicated host, power cycling, bench reservation, or instrument access.
+
+### D-05 — Directory split
+
+```
+tests/hil/basic/              — primitive driver tests; no machine stack
+tests/hil/machine/linuxcnc/   — full DM542 config, wcomp, homing
+```
+
+`applyTo: "tests/hil/**"` in the instruction covers both.
+
+### D-06 — `HIL-observed` status category
+
+Add `HIL-observed` as a category between `Assumed` and `Unit-tested`:
+
+| Status | Meaning |
+|---|---|
+| `HIL-observed` | Real board behavior was observed and recorded as oracle evidence |
+| `HIL-test-executed` | Named HIL test ran, regardless of outcome |
+| `HIL-verified` | Named HIL test passed on the named fixture revision |
+| `Timing-validated` | Timing measured against a documented threshold |
+
+Do not redefine `RT-validated`; the repository engineering contract owns that term.
+Remove `HIL-tested` — its distinction from `HIL-verified` is unclear.
+
+### D-07 — `applyTo` scope: `tests/hil/**` only
+
+Do not expand to `*.hal`, `*.ini`, or `.github/workflows/**`. That would load HIL
+safety rules when editing any HAL file, recreating the context-inflation problem
+corrected in PR #135.
+
+### D-08 — Fixture is a draft until hardware questions are resolved
+
+The fixture YAML must carry `fixture_status: draft` and `runnable: false` until
+all verification fields are confirmed. Per-loopback safe-state must be defined per
+channel, not as a global `false`. The value `false` ≠ electrically inactive for
+inverted or active-low outputs.
+
+---
+
+## 3. Claim Matrix (summary)
+
+| ID | Claim | Classification | Decision |
+|---|---|---|---|
+| C-01 | Physical pin N = HAL index N−1 | Verified (SimPins.hal) | Encode as fixture invariant |
+| C-02 | HIL does not replace unit/protocol tests | Supported | Adopt as rule |
+| C-03 | DM542 config is integration scope | Proposal | Accept (D-02) |
+| C-04 | wcomp is Layer 3 / integration | Proposal | Accept (D-02) |
+| C-05 | Emergency wired Pin 33 → Pin 52 | Provenance | Excluded (D-03) |
+| C-06 | INI `PEv2_EmergencyInputPin=54` | Provenance | Excluded (D-03) |
+| C-07/08 | Instruction file name | Conflict | Resolved: `hil-tdd` (D-01) |
+| C-09 | No dedicated HIL agent | Supported | Adopt (D-04) |
+| C-10 | AxisEnableOutputPins_N=1 conflicts FastEncoder1A | Proposal | Deferred (HW-3) |
+| C-11 | PWM→ADC needs RC filter | Supported | Documented constraint |
+| C-12 | `HIL-observed` status category | Proposal | Accept (D-06) |
+| C-13 | `applyTo: tests/hil/**` only | Proposal | Accept (D-07) |
+| C-14 | Agent routing hooks only | Supported | Adopt |
+| C-15 | First PR: documentation and skeleton only | Supported | Adopt |
+| C-16 | Loopback pairs from SimPins.hal | Provenance | Unconfirmed; mark as such |
+| C-17 | Pins 9, 11, 51 reserved for OC16-CNC | Supported | Encode in YAML |
+| C-18 | PWM pins 17–22, ADC pins 41–47 | Supported | Encode in fixture MD |
+| C-19/20 | Separate hil/basic and hil/machine dirs | Proposal | Accept (D-05) |
+
+---
+
+## 4. Unresolved Hardware Questions
+
+All hardware questions block at least one capability or loopback entry in the
+fixture. They cannot be resolved from documents alone.
+
+| ID | Question | Blocks |
+|---|---|---|
+| HW-0 | Actual device identity and firmware version | Device identity fields in YAML |
+| HW-1 | Emergency wiring: Pin 52 or Pin 54? | Emergency loopback |
+| HW-2 | `PEv2_EmergencyInputPin`: physical pin or API index? | Emergency loopback |
+| HW-3 | `PEv2_AxisEnableOutputPins_N=1` vs FastEncoder1A on pin 1 | PE/encoder tests |
+| HW-4 | Physical continuity of declared loopback pairs | All loopbacks (currently provenance only) |
+| HW-5 | Polarity and pull-up configuration of loopback endpoints | Safe-state definitions |
+
+---
+
+## 5. Canonical Document Architecture
+
+| Source document | Disposition |
+|---|---|
+| `HIL_TDD_guidance_suggestion1.md` | Archive — superseded by this synthesis |
+| `HIL_moduletests_thoughts.md` | Delete — exact content duplicate of suggestion1 |
+| `PoKeys57E pin modes.md` | Retain content → `tests/hil/setups/pokeys57e-loopback-v1.md` |
+| `TDD Guidance for PokeysHal1.md` | Oracle model merged into `hil-tdd/SKILL.md` → archive |
+| `TDD Guidance for PokeysHal2.md` | Layer separation merged into `hil-tdd/SKILL.md` → archive |
+| `TDD_HILguidance_thoughts.md` | Primary draft source for instruction and skill → archive |
+
+Target: six guidance documents → two live artifacts (instruction + skill) + fixture
+YAML/MD pair + oracle log. No overlapping active guidance documents.
+
+---
+
+## 6. Inputs Required for Infrastructure Audit
+
+Before running `tdd-hil-infrastructure-audit.prompt.md`, confirm:
+
+1. This synthesis document is committed and accessible at
+   `docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md`.
+2. Whether `apply-tdd-infrastructure-plan.prompt.md` should be invoked after the
+   audit or whether the audit output becomes a GitHub issue independently.
+3. The current LinuxCNC version and kernel RT type on the test machine.
+4. Whether a self-hosted GitHub Actions runner exists for the fixture host.
+5. Whether the target HAL component is `pokeys_async` (the async rewrite) or
+   the legacy `pokeys` userspace component — the machine HAL loads `pokeys`,
+   but the build targets `pokeys_async`.

--- a/docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md
+++ b/docs/HIL_Setup_4_TDD/HIL_TDD_synthesis.md
@@ -1,9 +1,13 @@
 # HIL/TDD Guidance Synthesis
 
-**Status**: Approved  
-**Date**: 2026-07-30  
-**Input documents**: 6 thought documents in `docs/HIL_Setup_4_TDD/`  
+**Status**: Approved for documentation/skeleton scope
+**Date**: 2026-07-30
+**Input documents**: 6 thought documents in `docs/HIL_Setup_4_TDD/`
 **Produces**: authoritative input for `tdd-hil-infrastructure-audit.prompt.md`
+
+**Approval metadata**: this synthesis was accepted as the basis for the initial HIL-TDD infrastructure skeleton in PR #139. No hardware runs were executed in this phase; evidence is limited to fixture definitions, documented constraints, and review-approved guidance.
+
+**Conflict and resolution**: earlier drafts conflated primitive HIL with machine integration and used ambiguous status terms. The active guidance now separates those scopes, centralizes status vocabulary in the HIL result schema, and keeps the fixture draft until HW-0 through HW-5 are resolved.
 
 ---
 
@@ -72,7 +76,7 @@ Add `HIL-observed` as a category between `Assumed` and `Unit-tested`:
 | `Timing-validated` | Timing measured against a documented threshold |
 
 Do not redefine `RT-validated`; the repository engineering contract owns that term.
-Remove `HIL-tested` — its distinction from `HIL-verified` is unclear.
+Remove the legacy status label — its distinction from `HIL-verified` is unclear.
 
 ### D-07 — `applyTo` scope: `tests/hil/**` only
 

--- a/docs/testing/pokeys57e-hil-observations.md
+++ b/docs/testing/pokeys57e-hil-observations.md
@@ -17,14 +17,15 @@ Each observation entry:
 - **Commit**: <SHA>
 
 **Wiring**: Physical Pin X → Physical Pin Y
-**HAL output**: `pokeys.0.digout.NN.out`
-**Observed HAL input**: `pokeys.0.PEv2.N.digin.XXX.in`
+**HAL source**: `pokeys.0.digout.NN.out`
+**Observed raw digital input**: `pokeys.0.digin.MM.in`
+**Observed PEv2 logical input**: `pokeys.0.PEv2.N.digin.XXX.in`
 
 **Observation**:
 - source HAL command: (e.g., `halcmd setp pokeys.0.digout.22.out false`)
-- source physical voltage: (measured or inferred)
-- sink raw digital value: (e.g., `halcmd gets pokeys.0.digout.27.in`)
-- PEv2 logical value: (e.g., `halcmd gets pokeys.0.PEv2.0.digin.LimitN.in`)
+- source physical level: (measured as high/low or voltage)
+- sink raw digital reading: (e.g., `halcmd gets pokeys.0.digin.27.in`)
+- PEv2 logical reading: (e.g., `halcmd gets pokeys.0.PEv2.0.digin.LimitN.in`)
 - configured inversion: (yes/no; INI/HAL source)
 - settling/update time: (observed or estimated)
 

--- a/docs/testing/pokeys57e-hil-observations.md
+++ b/docs/testing/pokeys57e-hil-observations.md
@@ -1,0 +1,55 @@
+# PoKeys57E HIL Observations
+
+This file records real hardware observations used as unit-test oracles.
+
+## Format
+
+Each observation entry:
+
+```markdown
+## HIL-P57E-XXX-NNN — <short description>
+
+- **Date**: YYYY-MM-DD
+- **Device**: PoKeys57E
+- **Device ID**: <id from halcmd show param>
+- **Firmware**: <version>
+- **Setup ID**: pokeys57e-loopback-v1 rev <N>
+- **Commit**: <SHA>
+
+**Wiring**: Physical Pin X → Physical Pin Y  
+**HAL output**: `pokeys.0.digout.NN.out`  
+**Expected input**: `pokeys.0.PEv2.N.digin.XXX.in`
+
+**Observation**:
+- output false → input false/inactive (verified)
+- output true → input true/active (verified)
+- output false → input false/inactive (verified)
+
+**Verified by**: tests/hil/basic/pytest/test_XXX.py  
+**Used as oracle in**: tests/unit/test_XXX.c
+```
+
+Unit tests citing an oracle must include:
+```c
+/* Oracle: HIL-P57E-DIO-001, observed on PoKeys57E DEVICE_ID=27295 */
+```
+
+---
+
+## Observations
+
+*No observations recorded yet. Add entries after physical fixture runs.*
+
+### Pending — to be recorded when fixture is confirmed
+
+- HIL-P57E-DIO-001: Physical Pin 23 → Pin 28 loopback (x-limit-negative)
+- HIL-P57E-DIO-002: Physical Pin 24 → Pin 29 loopback (x-home)
+- HIL-P57E-DIO-003: Physical Pin 25 → Pin 30 loopback (x2-limit-negative)
+- HIL-P57E-DIO-004: Physical Pin 26 → Pin 31 loopback (x2-home)
+- HIL-P57E-DIO-005: Physical Pin 12 → Pin 37 loopback (y-limit-negative)
+- HIL-P57E-DIO-006: Physical Pin 13 → Pin 38 loopback (y-home)
+- HIL-P57E-DIO-007: Physical Pin 14 → Pin 39 loopback (z-limit-negative)
+- HIL-P57E-DIO-008: Physical Pin 15 → Pin 40 loopback (z-home)
+
+All pending until HW-4 (physical continuity) and HW-5 (polarity) are confirmed.
+See issue #138.

--- a/docs/testing/pokeys57e-hil-observations.md
+++ b/docs/testing/pokeys57e-hil-observations.md
@@ -16,16 +16,19 @@ Each observation entry:
 - **Setup ID**: pokeys57e-loopback-v1 rev <N>
 - **Commit**: <SHA>
 
-**Wiring**: Physical Pin X → Physical Pin Y  
-**HAL output**: `pokeys.0.digout.NN.out`  
-**Expected input**: `pokeys.0.PEv2.N.digin.XXX.in`
+**Wiring**: Physical Pin X → Physical Pin Y
+**HAL output**: `pokeys.0.digout.NN.out`
+**Observed HAL input**: `pokeys.0.PEv2.N.digin.XXX.in`
 
 **Observation**:
-- output false → input false/inactive (verified)
-- output true → input true/active (verified)
-- output false → input false/inactive (verified)
+- source HAL command: (e.g., `halcmd setp pokeys.0.digout.22.out false`)
+- source physical voltage: (measured or inferred)
+- sink raw digital value: (e.g., `halcmd gets pokeys.0.digout.27.in`)
+- PEv2 logical value: (e.g., `halcmd gets pokeys.0.PEv2.0.digin.LimitN.in`)
+- configured inversion: (yes/no; INI/HAL source)
+- settling/update time: (observed or estimated)
 
-**Verified by**: tests/hil/basic/pytest/test_XXX.py  
+**Verified by**: tests/hil/basic/pytest/test_XXX.py
 **Used as oracle in**: tests/unit/test_XXX.c
 ```
 

--- a/docs/testing/pokeys57e-hil-observations.md
+++ b/docs/testing/pokeys57e-hil-observations.md
@@ -23,11 +23,12 @@ Each observation entry:
 
 **Observation**:
 - source HAL command: (e.g., `halcmd setp pokeys.0.digout.22.out false`)
-- source physical level: (measured as high/low or voltage)
+- source physical level: <measured voltage/high/low | not measured>
+- measurement instrument: <instrument/model | none>
 - sink raw digital reading: (e.g., `halcmd gets pokeys.0.digin.27.in`)
 - PEv2 logical reading: (e.g., `halcmd gets pokeys.0.PEv2.0.digin.LimitN.in`)
 - configured inversion: (yes/no; INI/HAL source)
-- settling/update time: (observed or estimated)
+- settling/update time: <measured value and method | not measured>
 
 **Verified by**: tests/hil/basic/pytest/test_XXX.py
 **Used as oracle in**: tests/unit/test_XXX.c
@@ -35,7 +36,7 @@ Each observation entry:
 
 Unit tests citing an oracle must include:
 ```c
-/* Oracle: HIL-P57E-DIO-001, observed on PoKeys57E DEVICE_ID=27295 */
+/* Oracle: HIL-P57E-DIO-001, setup=pokeys57e-loopback-v1 rev=1, device=<verified-id> */
 ```
 
 ---

--- a/tests/hil/basic/README.md
+++ b/tests/hil/basic/README.md
@@ -58,9 +58,11 @@ Tests must run in ID order. Each layer depends on the previous passing.
 ## Running
 
 ```bash
-# Requires physical PoKeys57E fixture and self-hosted runner label
+# Requires physical PoKeys57E fixture and self-hosted runner
 POKEYS_HIL=1 POKEYS_DEVICE_ID=27295 pytest -m hil tests/hil/basic -v
 ```
 
-Do not run on standard GitHub-hosted CI. Use the manual workflow
-`.github/workflows/hil-pokeys57e.yml`.
+A self-hosted HIL workflow is planned but not implemented in this revision.
+Run no automated HIL tests until the fixture is verified (`runnable: true`)
+and a runner with the physical device is available.
+Do not run on standard GitHub-hosted CI.

--- a/tests/hil/basic/README.md
+++ b/tests/hil/basic/README.md
@@ -22,7 +22,7 @@ The following must not be loaded from any test in this directory:
 - `pokeys_homing.hal`
 - `wcomp` window-comparator simulated switches
 
-If a test requires any of those, it belongs in `tests/integration/linuxcnc/`.
+If a test requires any of those, it belongs in `tests/hil/machine/linuxcnc/`.
 
 ## Directory layout
 
@@ -40,8 +40,11 @@ All tests in this directory must use setup ID: `pokeys57e-loopback-v1`
 
 The fixture definition is at: `tests/hil/setups/pokeys57e-loopback-v1.yaml`
 
-Tests must be guarded by `POKEYS_HIL=1` environment variable and skipped
-(not failed) when the variable is absent or the device is unreachable.
+Tests must be guarded by `POKEYS_HIL=1` environment variable. When the variable
+is absent, record `SKIPPED`. When the runner is not a HIL-capable host, or the
+fixture is not runnable, or the device identity cannot be confirmed, record
+`ERROR`. Use `FAIL` only when the hardware behavior diverges from the expected
+oracle.
 
 ## Test order
 
@@ -59,7 +62,7 @@ Tests must run in ID order. Each layer depends on the previous passing.
 
 ```bash
 # Requires physical PoKeys57E fixture and self-hosted runner
-POKEYS_HIL=1 POKEYS_DEVICE_ID=27295 pytest -m hil tests/hil/basic -v
+POKEYS_HIL=1 POKEYS_DEVICE_ID=<candidate-id-from-fixture> pytest -m hil tests/hil/basic -v
 ```
 
 A self-hosted HIL workflow is planned but not implemented in this revision.

--- a/tests/hil/basic/README.md
+++ b/tests/hil/basic/README.md
@@ -1,0 +1,66 @@
+# tests/hil/basic — Primitive HIL Tests
+
+## Scope
+
+These tests verify PoKeysHal driver behavior against the physical PoKeys57E
+loopback fixture using the **smallest possible HAL configuration**. They test
+driver hardware contracts — not machine behavior.
+
+## What belongs here
+
+- Direct digital output → input loopback (HIL-010)
+- PWM/ADC loopback (HIL-020, requires RC filter hardware, not yet in v1)
+- Pulse engine → fast encoder feedback (HIL-030, pending HW-3 resolution)
+
+## What does NOT belong here
+
+The following must not be loaded from any test in this directory:
+
+- `motmod` or any LinuxCNC kinematics component
+- `trivkins`, `gantrykins`, or AXIS/Touchy UI
+- The full `DM542_XXYZ_mill` HAL/INI stack
+- `pokeys_homing.hal`
+- `wcomp` window-comparator simulated switches
+
+If a test requires any of those, it belongs in `tests/integration/linuxcnc/`.
+
+## Directory layout
+
+```
+tests/hil/basic/
+  README.md               — this file
+  hal/                    — minimal HAL files (one per test category)
+  pytest/                 — pytest test cases
+  conftest.py             — fixture identity check, exclusive lock, safe-state setup/teardown
+```
+
+## Fixture
+
+All tests in this directory must use setup ID: `pokeys57e-loopback-v1`
+
+The fixture definition is at: `tests/hil/setups/pokeys57e-loopback-v1.yaml`
+
+Tests must be guarded by `POKEYS_HIL=1` environment variable and skipped
+(not failed) when the variable is absent or the device is unreachable.
+
+## Test order
+
+Tests must run in ID order. Each layer depends on the previous passing.
+
+| ID | Name | Status |
+|---|---|---|
+| HIL-000 | Identity and HAL export | Not yet implemented |
+| HIL-010 | Direct digital loopback | Not yet implemented |
+| HIL-020 | PWM/ADC loopback | Excluded from v1 (RC filter required) |
+| HIL-030 | PE to fast encoder loopback | Excluded from v1 (HW-3 open) |
+| HIL-040 | Emergency loopback | Excluded from v1 (HW-1/HW-2 open) |
+
+## Running
+
+```bash
+# Requires physical PoKeys57E fixture and self-hosted runner label
+POKEYS_HIL=1 POKEYS_DEVICE_ID=27295 pytest -m hil tests/hil/basic -v
+```
+
+Do not run on standard GitHub-hosted CI. Use the manual workflow
+`.github/workflows/hil-pokeys57e.yml`.

--- a/tests/hil/basic/README.md
+++ b/tests/hil/basic/README.md
@@ -41,10 +41,11 @@ All tests in this directory must use setup ID: `pokeys57e-loopback-v1`
 The fixture definition is at: `tests/hil/setups/pokeys57e-loopback-v1.yaml`
 
 Tests must be guarded by `POKEYS_HIL=1` environment variable. When the variable
-is absent, record `SKIPPED`. When the runner is not a HIL-capable host, or the
-fixture is not runnable, or the device identity cannot be confirmed, record
-`ERROR`. Use `FAIL` only when the hardware behavior diverges from the expected
-oracle.
+is absent, record `SKIPPED`. When the test suite is discovered on a non-HIL runner
+without HIL being requested, record `SKIPPED`. When `POKEYS_HIL=1` but the runner
+lacks the fixture, the fixture is draft or not runnable, or the device identity
+cannot be confirmed, record `ERROR`. Use `FAIL` only when the hardware behavior
+diverges from the expected oracle.
 
 ## Test order
 
@@ -62,7 +63,7 @@ Tests must run in ID order. Each layer depends on the previous passing.
 
 ```bash
 # Requires physical PoKeys57E fixture and self-hosted runner
-POKEYS_HIL=1 POKEYS_DEVICE_ID=<candidate-id-from-fixture> pytest -m hil tests/hil/basic -v
+POKEYS_HIL=1 POKEYS_DEVICE_ID=<verified-expected-device-id-from-fixture> pytest -m hil tests/hil/basic -v
 ```
 
 A self-hosted HIL workflow is planned but not implemented in this revision.

--- a/tests/hil/machine/linuxcnc/README.md
+++ b/tests/hil/machine/linuxcnc/README.md
@@ -34,7 +34,7 @@ belong in `tests/hil/basic/` where failures are diagnosable against a single sub
 ## Directory layout
 
 ```
-tests/integration/linuxcnc/
+tests/hil/machine/linuxcnc/
   README.md                  — this file
   DM542_XXYZ_mill/           — full INI/HAL configuration under test
     Pokeys57E_DM542_XXYZ_mill.ini

--- a/tests/hil/machine/linuxcnc/README.md
+++ b/tests/hil/machine/linuxcnc/README.md
@@ -1,16 +1,20 @@
-# tests/integration/linuxcnc — Machine Integration Tests
+# tests/hil/machine/linuxcnc — Machine Integration Tests
 
 ## Scope
 
 These tests verify the full `DM542_XXYZ_mill` LinuxCNC machine configuration,
 including homing, simulated switches, kinematics, and the complete HAL/INI stack.
+They use the same physical PoKeys57E loopback fixture but load the full machine
+configuration, placing them in the `tests/hil/` tree so the HIL safety instruction
+(`applyTo: tests/hil/**`) applies.
 
 Integration tests intentionally test the combination of:
 driver behavior + HAL naming + INI parameter propagation + homing algorithm +
 `wcomp` window comparators + joint mappings + machine-on/e-stop routing.
 
 A failure here can come from any of those layers. Use primitive HIL tests
-(`tests/hil/basic/`) first to isolate driver-level defects.
+(`tests/hil/basic/`) first to isolate driver-level defects before running
+machine integration tests.
 
 ## What belongs here
 

--- a/tests/hil/machine/linuxcnc/README.md
+++ b/tests/hil/machine/linuxcnc/README.md
@@ -36,13 +36,15 @@ belong in `tests/hil/basic/` where failures are diagnosable against a single sub
 ```
 tests/hil/machine/linuxcnc/
   README.md                  — this file
-  DM542_XXYZ_mill/           — full INI/HAL configuration under test
-    Pokeys57E_DM542_XXYZ_mill.ini
-    Pokeys_DM542_XXYZ_mill.hal
-    pokeys_homing.hal
-    Pokeys57E_SimPins.hal
+  # Planned:
+  DM542_XXYZ_mill/           — full INI/HAL configuration to be imported or recreated
   pytest/                    — integration test cases
 ```
+
+The intended machine integration coverage is a LinuxCNC `DM542_XXYZ_mill` stack
+with `wcomp`-based simulated switches and homing wiring. Any external
+`Pokeys57E_SimPins.hal` reference should be treated as historical provenance only;
+it is not assumed to exist in this repository.
 
 ## Status
 

--- a/tests/hil/setups/pokeys57e-loopback-v1.md
+++ b/tests/hil/setups/pokeys57e-loopback-v1.md
@@ -1,0 +1,126 @@
+# PoKeys57E HIL Fixture — Loopback v1
+
+**Setup ID**: `pokeys57e-loopback-v1`  **Revision**: 1  
+**Device**: PoKeys57E  **Expected device ID**: 27295 (unconfirmed — see HW-4)  
+**Transport**: Ethernet
+
+---
+
+> **Provenance notice**: The wiring below is derived from `Pokeys57E_SimPins.hal`
+> (historical machine configuration). Physical continuity has not been independently
+> confirmed. All loopbacks are marked `status: unconfirmed` in the YAML until
+> verified by a continuity or controlled toggle test (HW-4).
+
+---
+
+## Pin numbering invariant
+
+PoKeys57E physical pin numbers are 1-based. HAL channel indices are 0-based.
+
+```
+Physical Pin N  →  HAL channel N−1
+Physical Pin 23 →  pokeys.0.digout.22.out   ✓ confirmed from SimPins.hal
+Physical Pin 12 →  pokeys.0.digout.11.out   ✓ confirmed from SimPins.hal
+```
+
+Do not treat physical pin numbers and HAL channel indices as interchangeable.
+
+---
+
+## Digital loopback wiring
+
+| ID | Physical out | Physical in | HAL output | PEv2 logical input | INI active? |
+|---|---|---|---|---|---|
+| x-limit-negative | 23 | 28 | `digout.22.out` | `PEv2.0.digin.LimitN.in` | Yes — limit-minus |
+| x-home | 24 | 29 | `digout.23.out` | `PEv2.0.digin.Home.in` | Yes |
+| x2-limit-negative | 25 | 30 | `digout.24.out` | `PEv2.6.digin.LimitN.in` | Yes — limit-minus |
+| x2-home | 26 | 31 | `digout.25.out` | `PEv2.6.digin.Home.in` | Yes |
+| y-limit-negative | 12 | 37 | `digout.11.out` | `PEv2.1.digin.LimitN.in` | Yes — limit-minus |
+| y-home | 13 | 38 | `digout.12.out` | `PEv2.1.digin.Home.in` | Yes |
+| z-limit-negative | 14 | 39 | `digout.13.out` | `PEv2.2.digin.LimitN.in` | Yes — limit-minus |
+| z-home | 15 | 40 | `digout.14.out` | `PEv2.2.digin.Home.in` | Yes |
+
+HAL pin prefix for all: `pokeys.0.`
+
+**Inversion**: The INI enables inversion for X and X2 LimitN and Home inputs.
+Test raw electrical state (`digout.NN.out` / raw digin) and PEv2 logical state
+(`PEv2.N.digin.LimitN.in`) **separately**.
+
+**Positive limits**: The current INI disables positive limits for X, X2, Y, Z.
+Do not test positive limit behavior in v1.
+
+---
+
+## Pin capabilities relevant to declared loopbacks
+
+| Physical pin | GPIO | Counter | Fast Encoder | LCD/Matrix | PEv2 function |
+|---|---|---|---|---|---|
+| 12 | I/O | — | UFE B | — | — |
+| 13 | I/O | — | UFE index | — | — |
+| 14 | I/O | — | — | — | — |
+| 15 | I/O | 15 | FE3 A | — | — |
+| 23 | I/O | 23 | — | LCD primary D7, Matrix LED 2 DATA | — |
+| 24 | I/O | 24 | — | LCD primary D6, Matrix LED 2 LATCH | — |
+| 25 | I/O | 25 | — | LCD primary D5, Matrix LED 2 CLOCK | — |
+| 26 | I/O | 26 | — | LCD primary D4 | — |
+| 28 | I/O | 28 | — | LCD R/W | — |
+| 29 | I/O | — | — | LCD RS | — |
+| 30 | I/O | — | — | LCD E | — |
+| 31 | I/O | — | — | LCD secondary D7 | — |
+| 37 | I/O | — | — | — | ext-gen dedicated-I/O / PoExtBus latch |
+| 38 | I/O | — | — | — | integrated PE DIR X / ext-gen dedicated-I/O |
+| 39 | I/O | — | — | — | integrated PE DIR Y |
+| 40 | I/O | — | — | — | integrated PE DIR Z |
+
+Source: PoKeys57 user manual. Alt functions for pins 38–40 apply only when the
+**integrated** pulse generator is selected; they are ordinary GPIO with the
+OC16-CNC external generator.
+
+---
+
+## Reserved pins (must not be used by HIL tests)
+
+| Physical pin | Function | Reason |
+|---|---|---|
+| 9 | PE external DATA | OC16-CNC reserved |
+| 11 | PE external CLOCK | OC16-CNC reserved |
+| 51 | PE external LATCH | OC16-CNC reserved |
+| 52 | PE emergency input | EXCLUDED — see HW-1/HW-2 |
+| 53 | PE charge-pump output | Reserved |
+| 1, 2 | Fast Encoder 1 A/B | Encoder feedback path |
+| 5, 6 | Fast Encoder 2 A/B | Encoder feedback path (HW coupling: both must match direction simultaneously) |
+
+---
+
+## Excluded capabilities (not in v1 scope)
+
+| Capability | Reason excluded |
+|---|---|
+| Emergency loopback (Pin 33 → Pin 52) | HW-1: SimPins.hal says 52; INI says `PEv2_EmergencyInputPin=54`. Unresolved. |
+| PWM → ADC loopback | Requires RC low-pass filter (4.7 kΩ + 1 µF) at each connection. Not yet fitted. |
+| PE → fast encoder feedback | HW-3: `PEv2_AxisEnableOutputPins_N=1` may conflict with Fast Encoder 1A on pin 1. |
+
+---
+
+## Open hardware questions
+
+| ID | Question | Blocking |
+|---|---|---|
+| HW-1 | Is the emergency loopback wired to Pin 52 or Pin 54? | Emergency tests |
+| HW-2 | Is `PEv2_EmergencyInputPin` a physical pin number or API index? | Emergency tests |
+| HW-3 | Does `PEv2_AxisEnableOutputPins_N=1` conflict with Fast Encoder 1A on pin 1? | PE/encoder tests |
+| HW-4 | Physical continuity of all declared loopback pairs confirmed? | All loopbacks |
+| HW-5 | Polarity/pull-up configuration of loopback endpoints? | Polarity fields in YAML |
+
+Track these in issue #138.
+
+---
+
+## Safety rules
+
+- All outputs must be driven to false/inactive before any test.
+- Acquire exclusive fixture lock before changing any output.
+- Restore all outputs to false/inactive after every test, even on failure.
+- A series resistor (~1–4.7 kΩ) per GPIO loopback is recommended to limit current
+  if a test defect configures both endpoints as opposing outputs.
+- Exactly one endpoint must be configured as an active output at any time.

--- a/tests/hil/setups/pokeys57e-loopback-v1.md
+++ b/tests/hil/setups/pokeys57e-loopback-v1.md
@@ -6,8 +6,10 @@
 
 ---
 
-> **Provenance notice**: The wiring below is derived from `Pokeys57E_SimPins.hal`
-> (historical machine configuration). Physical continuity has not been independently
+> **Provenance notice**: The wiring below is derived from the historical external configuration
+> `zarfld/LinuxCnc_PokeysLibComp/DM542_XXYZ_mill/Pokeys57E_SimPins.hal`.
+> That file supports the documented indexing convention but does not verify the
+> present fixture wiring. Physical continuity has not been independently
 > confirmed. All loopbacks are marked `status: unconfirmed` in the YAML until
 > verified by a continuity or controlled toggle test (HW-4).
 
@@ -19,8 +21,8 @@ PoKeys57E physical pin numbers are 1-based. HAL channel indices are 0-based.
 
 ```
 Physical Pin N  →  HAL channel N−1
-Physical Pin 23 →  pokeys.0.digout.22.out   ✓ confirmed from SimPins.hal
-Physical Pin 12 →  pokeys.0.digout.11.out   ✓ confirmed from SimPins.hal
+Physical Pin 23 →  pokeys.0.digout.22.out   documented in the historical configuration; not independently verified on this fixture
+Physical Pin 12 →  pokeys.0.digout.11.out   documented in the historical configuration; not independently verified on this fixture
 ```
 
 Do not treat physical pin numbers and HAL channel indices as interchangeable.
@@ -96,7 +98,7 @@ OC16-CNC external generator.
 
 | Capability | Reason excluded |
 |---|---|
-| Emergency loopback (Pin 33 → Pin 52) | HW-1: SimPins.hal says 52; INI says `PEv2_EmergencyInputPin=54`. Unresolved. |
+| Emergency loopback (Pin 33 → Pin 52) | HW-1: the historical external configuration points to 52; the INI says `PEv2_EmergencyInputPin=54`. Unresolved. |
 | PWM → ADC loopback | Requires RC low-pass filter (4.7 kΩ + 1 µF) at each connection. Not yet fitted. |
 | PE → fast encoder feedback | HW-3: `PEv2_AxisEnableOutputPins_N=1` may conflict with Fast Encoder 1A on pin 1. |
 
@@ -121,6 +123,5 @@ Track these in issue #138.
 - Before any test, drive each source channel to its fixture-defined `safe_logical_value` and verify the corresponding `expected_safe_physical_level`.
 - Acquire exclusive fixture lock before changing any output.
 - Restore each source channel to its fixture-defined safe state after every test, even on failure.
-- A series resistor (~1–4.7 kΩ) per GPIO loopback is recommended to limit current
-  if a test defect configures both endpoints as opposing outputs.
+- A series resistor (~1–4.7 kΩ) per GPIO loopback is required for unattended automated loopback tests to limit current if a test defect configures both endpoints as opposing outputs.
 - Exactly one endpoint must be configured as an active output at any time.

--- a/tests/hil/setups/pokeys57e-loopback-v1.md
+++ b/tests/hil/setups/pokeys57e-loopback-v1.md
@@ -1,7 +1,7 @@
 # PoKeys57E HIL Fixture — Loopback v1
 
-**Setup ID**: `pokeys57e-loopback-v1`  **Revision**: 1  
-**Device**: PoKeys57E  **Expected device ID**: 27295 (unconfirmed — see HW-4)  
+**Setup ID**: `pokeys57e-loopback-v1`  **Revision**: 1
+**Device**: PoKeys57E  **Expected device ID**: unset while the fixture is draft; candidate ID 27295 pending HW-0 verification
 **Transport**: Ethernet
 
 ---
@@ -118,9 +118,9 @@ Track these in issue #138.
 
 ## Safety rules
 
-- All outputs must be driven to false/inactive before any test.
+- Before any test, drive each source channel to its fixture-defined `safe_logical_value` and verify the corresponding `expected_safe_physical_level`.
 - Acquire exclusive fixture lock before changing any output.
-- Restore all outputs to false/inactive after every test, even on failure.
+- Restore each source channel to its fixture-defined safe state after every test, even on failure.
 - A series resistor (~1–4.7 kΩ) per GPIO loopback is recommended to limit current
   if a test defect configures both endpoints as opposing outputs.
 - Exactly one endpoint must be configured as an active output at any time.

--- a/tests/hil/setups/pokeys57e-loopback-v1.md
+++ b/tests/hil/setups/pokeys57e-loopback-v1.md
@@ -108,6 +108,7 @@ OC16-CNC external generator.
 
 | ID | Question | Blocking |
 |---|---|---|
+| HW-0 | Confirm actual PoKeys57E identity and firmware version | Fixture identity and activation |
 | HW-1 | Is the emergency loopback wired to Pin 52 or Pin 54? | Emergency tests |
 | HW-2 | Is `PEv2_EmergencyInputPin` a physical pin number or API index? | Emergency tests |
 | HW-3 | Does `PEv2_AxisEnableOutputPins_N=1` conflict with Fast Encoder 1A on pin 1? | PE/encoder tests |

--- a/tests/hil/setups/pokeys57e-loopback-v1.yaml
+++ b/tests/hil/setups/pokeys57e-loopback-v1.yaml
@@ -3,7 +3,8 @@ setup_id: pokeys57e-loopback-v1
 revision: 1
 
 # Physical continuity of declared loopbacks has NOT been independently confirmed.
-# This definition is derived from Pokeys57E_SimPins.hal (provenance).
+# This definition is derived from the historical external configuration
+# zarfld/LinuxCnc_PokeysLibComp/DM542_XXYZ_mill/Pokeys57E_SimPins.hal.
 # Verify with continuity test or controlled toggle before marking wiring as confirmed.
 
 # Runner must refuse to operate this fixture until fixture_status is 'verified'
@@ -32,7 +33,7 @@ safety:
   require_safe_reset_on_exit: true
 
 # HAL channel index = physical pin number - 1
-# Physical Pin 23 -> pokeys.0.digout.22.out  (confirmed from SimPins.hal)
+# Physical Pin 23 -> pokeys.0.digout.22.out  (documented in the historical external configuration; not independently verified)
 pin_numbering: physical_is_one_based_hal_index_is_zero_based
 
 # Capabilities are declared as draft; none are active until runnable: true

--- a/tests/hil/setups/pokeys57e-loopback-v1.yaml
+++ b/tests/hil/setups/pokeys57e-loopback-v1.yaml
@@ -6,26 +6,39 @@ revision: 1
 # This definition is derived from Pokeys57E_SimPins.hal (provenance).
 # Verify with continuity test or controlled toggle before marking wiring as confirmed.
 
+# Runner must refuse to operate this fixture until fixture_status is 'verified'
+# and runnable is true. See HW-0 through HW-5 in open_items.
+fixture_status: draft
+runnable: false
+
+verification:
+  device_identity_confirmed: false   # HW-0
+  continuity_confirmed: false        # HW-4
+  polarity_confirmed: false          # HW-5
+  electrical_protection_confirmed: false  # series resistors fitted?
+
 device:
   model: PoKeys57E
-  expected_device_id: 27295  # unconfirmed — verify via halcmd show param
+  candidate_device_id: 27295   # unconfirmed; set expected_device_id after HW-0
+  expected_device_id: null
   transport: ethernet
   exclusive_use: true
 
 safety:
   motion_allowed: false
   pulse_engine_allowed: false
-  startup_output_state: false    # all outputs driven to false before any test
-  cleanup_output_state: false    # all outputs restored to false after every test
+  # Safe state is defined per source channel (safe_logical_value below).
+  # Do not assume false == electrically inactive without confirming HW-5.
   require_safe_reset_on_exit: true
 
 # HAL channel index = physical pin number - 1
 # Physical Pin 23 -> pokeys.0.digout.22.out  (confirmed from SimPins.hal)
 pin_numbering: physical_is_one_based_hal_index_is_zero_based
 
+# Capabilities are declared as draft; none are active until runnable: true
 capabilities:
-  - digital-loopback
-  - pev2-limit-home
+  - digital-loopback   # draft — blocked by HW-4/HW-5
+  - pev2-limit-home    # draft — blocked by HW-4/HW-5
 
 # Excluded from v1 scope — hardware questions HW-1/HW-2 unresolved:
 # Pin 33 -> Pin 52 (SimPins.hal) vs PEv2_EmergencyInputPin=54 (INI).
@@ -47,10 +60,15 @@ loopbacks:
       physical_pin: 23
       hal_channel: 22     # physical - 1
       hal_pin: "pokeys.0.digout.22.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low   # unconfirmed — see HW-5
     sink:
       physical_pin: 28
       hal_channel: 27
       observed_hal_pin: "pokeys.0.PEv2.0.digin.LimitN.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
     inversion_note: "INI enables inversion for X LimitN; test raw and logical separately"
 
@@ -60,10 +78,15 @@ loopbacks:
       physical_pin: 24
       hal_channel: 23
       hal_pin: "pokeys.0.digout.23.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 29
       hal_channel: 28
       observed_hal_pin: "pokeys.0.PEv2.0.digin.Home.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
     inversion_note: "INI enables inversion for X Home"
 
@@ -73,10 +96,15 @@ loopbacks:
       physical_pin: 25
       hal_channel: 24
       hal_pin: "pokeys.0.digout.24.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 30
       hal_channel: 29
       observed_hal_pin: "pokeys.0.PEv2.6.digin.LimitN.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
 
   - id: x2-home
@@ -85,10 +113,15 @@ loopbacks:
       physical_pin: 26
       hal_channel: 25
       hal_pin: "pokeys.0.digout.25.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 31
       hal_channel: 30
       observed_hal_pin: "pokeys.0.PEv2.6.digin.Home.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
 
   - id: y-limit-negative
@@ -97,10 +130,15 @@ loopbacks:
       physical_pin: 12
       hal_channel: 11
       hal_pin: "pokeys.0.digout.11.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 37
       hal_channel: 36
       observed_hal_pin: "pokeys.0.PEv2.1.digin.LimitN.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
 
   - id: y-home
@@ -109,10 +147,15 @@ loopbacks:
       physical_pin: 13
       hal_channel: 12
       hal_pin: "pokeys.0.digout.12.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 38
       hal_channel: 37
       observed_hal_pin: "pokeys.0.PEv2.1.digin.Home.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
     note: "Pin 38 is also integrated-PE DIR-X when internal generator selected"
 
@@ -122,10 +165,15 @@ loopbacks:
       physical_pin: 14
       hal_channel: 13
       hal_pin: "pokeys.0.digout.13.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 39
       hal_channel: 38
       observed_hal_pin: "pokeys.0.PEv2.2.digin.LimitN.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
     note: "Pin 39 is also integrated-PE DIR-Y when internal generator selected"
 
@@ -135,15 +183,25 @@ loopbacks:
       physical_pin: 15
       hal_channel: 14
       hal_pin: "pokeys.0.digout.14.out"
+      startup_mode: high_impedance
+      test_mode: digital_output
+      safe_logical_value: false
+      expected_safe_physical_level: low
     sink:
       physical_pin: 40
       hal_channel: 39
       observed_hal_pin: "pokeys.0.PEv2.2.digin.Home.in"
+      required_mode_before_source_enable: digital_input
     polarity: verify-from-device-configuration
     note: "Pin 40 is also integrated-PE DIR-Z when internal generator selected"
 
 # Open hardware questions blocking v1 completion:
 open_items:
+  - id: HW-0
+    description: "Confirm actual PoKeys57E device identity and firmware version via halcmd show param"
+    affects: [device-identity]
+    issue: 138
+
   - id: HW-1
     description: "Verify physical wiring: does the loopback wire go to Pin 52 or Pin 54?"
     affects: [emergency-loopback]

--- a/tests/hil/setups/pokeys57e-loopback-v1.yaml
+++ b/tests/hil/setups/pokeys57e-loopback-v1.yaml
@@ -1,0 +1,170 @@
+schema_version: 1
+setup_id: pokeys57e-loopback-v1
+revision: 1
+
+# Physical continuity of declared loopbacks has NOT been independently confirmed.
+# This definition is derived from Pokeys57E_SimPins.hal (provenance).
+# Verify with continuity test or controlled toggle before marking wiring as confirmed.
+
+device:
+  model: PoKeys57E
+  expected_device_id: 27295  # unconfirmed — verify via halcmd show param
+  transport: ethernet
+  exclusive_use: true
+
+safety:
+  motion_allowed: false
+  pulse_engine_allowed: false
+  startup_output_state: false    # all outputs driven to false before any test
+  cleanup_output_state: false    # all outputs restored to false after every test
+  require_safe_reset_on_exit: true
+
+# HAL channel index = physical pin number - 1
+# Physical Pin 23 -> pokeys.0.digout.22.out  (confirmed from SimPins.hal)
+pin_numbering: physical_is_one_based_hal_index_is_zero_based
+
+capabilities:
+  - digital-loopback
+  - pev2-limit-home
+
+# Excluded from v1 scope — hardware questions HW-1/HW-2 unresolved:
+# Pin 33 -> Pin 52 (SimPins.hal) vs PEv2_EmergencyInputPin=54 (INI).
+# Also excluded: pwm-analog-loopback (requires RC filter hardware, not yet fitted).
+# Also excluded: pe-encoder-feedback (motor-enable conflict HW-3 unresolved).
+
+# Reserved pins — must not be used by HIL tests in this setup:
+reserved_pins:
+  - {physical: 9,  reason: "PE external DATA (OC16-CNC)"}
+  - {physical: 11, reason: "PE external CLOCK (OC16-CNC)"}
+  - {physical: 51, reason: "PE external LATCH (OC16-CNC)"}
+  - {physical: 52, reason: "PE emergency input — excluded, see HW-1/HW-2"}
+  - {physical: 53, reason: "PE charge-pump output"}
+
+loopbacks:
+  - id: x-limit-negative
+    status: unconfirmed   # physical continuity not independently verified
+    source:
+      physical_pin: 23
+      hal_channel: 22     # physical - 1
+      hal_pin: "pokeys.0.digout.22.out"
+    sink:
+      physical_pin: 28
+      hal_channel: 27
+      observed_hal_pin: "pokeys.0.PEv2.0.digin.LimitN.in"
+    polarity: verify-from-device-configuration
+    inversion_note: "INI enables inversion for X LimitN; test raw and logical separately"
+
+  - id: x-home
+    status: unconfirmed
+    source:
+      physical_pin: 24
+      hal_channel: 23
+      hal_pin: "pokeys.0.digout.23.out"
+    sink:
+      physical_pin: 29
+      hal_channel: 28
+      observed_hal_pin: "pokeys.0.PEv2.0.digin.Home.in"
+    polarity: verify-from-device-configuration
+    inversion_note: "INI enables inversion for X Home"
+
+  - id: x2-limit-negative
+    status: unconfirmed
+    source:
+      physical_pin: 25
+      hal_channel: 24
+      hal_pin: "pokeys.0.digout.24.out"
+    sink:
+      physical_pin: 30
+      hal_channel: 29
+      observed_hal_pin: "pokeys.0.PEv2.6.digin.LimitN.in"
+    polarity: verify-from-device-configuration
+
+  - id: x2-home
+    status: unconfirmed
+    source:
+      physical_pin: 26
+      hal_channel: 25
+      hal_pin: "pokeys.0.digout.25.out"
+    sink:
+      physical_pin: 31
+      hal_channel: 30
+      observed_hal_pin: "pokeys.0.PEv2.6.digin.Home.in"
+    polarity: verify-from-device-configuration
+
+  - id: y-limit-negative
+    status: unconfirmed
+    source:
+      physical_pin: 12
+      hal_channel: 11
+      hal_pin: "pokeys.0.digout.11.out"
+    sink:
+      physical_pin: 37
+      hal_channel: 36
+      observed_hal_pin: "pokeys.0.PEv2.1.digin.LimitN.in"
+    polarity: verify-from-device-configuration
+
+  - id: y-home
+    status: unconfirmed
+    source:
+      physical_pin: 13
+      hal_channel: 12
+      hal_pin: "pokeys.0.digout.12.out"
+    sink:
+      physical_pin: 38
+      hal_channel: 37
+      observed_hal_pin: "pokeys.0.PEv2.1.digin.Home.in"
+    polarity: verify-from-device-configuration
+    note: "Pin 38 is also integrated-PE DIR-X when internal generator selected"
+
+  - id: z-limit-negative
+    status: unconfirmed
+    source:
+      physical_pin: 14
+      hal_channel: 13
+      hal_pin: "pokeys.0.digout.13.out"
+    sink:
+      physical_pin: 39
+      hal_channel: 38
+      observed_hal_pin: "pokeys.0.PEv2.2.digin.LimitN.in"
+    polarity: verify-from-device-configuration
+    note: "Pin 39 is also integrated-PE DIR-Y when internal generator selected"
+
+  - id: z-home
+    status: unconfirmed
+    source:
+      physical_pin: 15
+      hal_channel: 14
+      hal_pin: "pokeys.0.digout.14.out"
+    sink:
+      physical_pin: 40
+      hal_channel: 39
+      observed_hal_pin: "pokeys.0.PEv2.2.digin.Home.in"
+    polarity: verify-from-device-configuration
+    note: "Pin 40 is also integrated-PE DIR-Z when internal generator selected"
+
+# Open hardware questions blocking v1 completion:
+open_items:
+  - id: HW-1
+    description: "Verify physical wiring: does the loopback wire go to Pin 52 or Pin 54?"
+    affects: [emergency-loopback]
+    issue: 138
+
+  - id: HW-2
+    description: "Confirm whether PEv2_EmergencyInputPin is a physical pin number or API index"
+    affects: [emergency-loopback]
+    issue: 138
+
+  - id: HW-3
+    description: "Confirm PEv2_AxisEnableOutputPins_N=1 does not conflict with Fast Encoder 1A on pin 1"
+    affects: [pe-encoder-feedback]
+    issue: 138
+
+  - id: HW-4
+    description: "Physical continuity test for all declared loopback pairs"
+    affects: [all-loopbacks]
+    issue: 138
+
+  - id: HW-5
+    description: "Confirm polarity/pull-up config of loopback endpoints; update polarity fields above"
+    affects: [all-loopbacks]
+    issue: 138

--- a/tests/integration/linuxcnc/README.md
+++ b/tests/integration/linuxcnc/README.md
@@ -1,0 +1,46 @@
+# tests/integration/linuxcnc — Machine Integration Tests
+
+## Scope
+
+These tests verify the full `DM542_XXYZ_mill` LinuxCNC machine configuration,
+including homing, simulated switches, kinematics, and the complete HAL/INI stack.
+
+Integration tests intentionally test the combination of:
+driver behavior + HAL naming + INI parameter propagation + homing algorithm +
+`wcomp` window comparators + joint mappings + machine-on/e-stop routing.
+
+A failure here can come from any of those layers. Use primitive HIL tests
+(`tests/hil/basic/`) first to isolate driver-level defects.
+
+## What belongs here
+
+- Full INI/HAL stack load verification (`DM542_XXYZ_mill`)
+- `Pokeys57E_SimPins.hal` with `wcomp` position-derived simulated switches
+- `pokeys_homing.hal` homing algorithm wiring
+- PEv2 axis switch configuration end-to-end
+- Spindle DAC scaling path
+- LinuxCNC joint wiring (`joint.N.motor-pos-cmd`, `joint.N.motor-pos-fb`)
+- Machine-on / e-stop / probe signal routing
+
+## What does NOT belong here
+
+Primitive driver tests (pin mapping, raw digital I/O, async mailbox, HAL export)
+belong in `tests/hil/basic/` where failures are diagnosable against a single subsystem.
+
+## Directory layout
+
+```
+tests/integration/linuxcnc/
+  README.md                  — this file
+  DM542_XXYZ_mill/           — full INI/HAL configuration under test
+    Pokeys57E_DM542_XXYZ_mill.ini
+    Pokeys_DM542_XXYZ_mill.hal
+    pokeys_homing.hal
+    Pokeys57E_SimPins.hal
+  pytest/                    — integration test cases
+```
+
+## Status
+
+Not yet implemented. Prerequisite: primitive HIL tests (HIL-000 through HIL-010)
+must pass on the physical fixture before integration tests are written.


### PR DESCRIPTION
Implements #138

## Summary

This PR adds the initial HIL-TDD infrastructure skeleton for PoKeysHal without introducing hardware execution in this phase.

### Included changes
- Added the HIL-TDD instruction and skill guidance under .github/instructions and .github/skills
- Added the shared HIL result schema and status vocabulary
- Added fixture metadata and documentation under tests/hil/setups
- Added primitive HIL and machine-integration README scaffolding under tests/hil/basic and tests/hil/machine/linuxcnc
- Added the HIL/TDD synthesis note documenting the accepted scope and draft-fixture gate
- Added staged Copilot prompts for guidance synthesis, infrastructure audit, and application of an approved infrastructure issue
- Added agent routing hooks and an observation log for future HIL evidence capture

### Scope note
- The fixture remains draft and non-runnable until hardware verification is completed.
- The work is documentation and skeleton infrastructure only; no hardware execution is required for this PR.

### Verification
- `git diff --check`
- Validation for instruction line budget, stale review terms, and updated documentation examples