### PR TITLE
docs: remove legacy HIL status from submodule skill

### DIFF
--- a/.github/skills/update-submodule/SKILL.md
+++ b/.github/skills/update-submodule/SKILL.md
@@ -71,7 +71,8 @@ Record the exact build/test results.
 Commit message must include:
 - Old SHA → new SHA
 - Summary of upstream changes reviewed
-- Build/test result (Compiled / Tested / Hardware-verified)
+- Build/test result: `Compiled`, `Tested`, or applicable HIL status from
+  `.github/skills/hil-tdd/references/result-schema.md`
 
 ### 8. Create a dedicated bump PR
 

--- a/.github/skills/update-submodule/SKILL.md
+++ b/.github/skills/update-submodule/SKILL.md
@@ -71,7 +71,8 @@ Record the exact build/test results.
 Commit message must include:
 - Old SHA → new SHA
 - Summary of upstream changes reviewed
-- Build/test result: `Compiled`, `Tested`, or applicable HIL status from
+- Build/test evidence: `Compiled` and/or `Tested`
+- When hardware/HIL work was performed, the applicable HIL status from
   `.github/skills/hil-tdd/references/result-schema.md`
 
 ### 8. Create a dedicated bump PR


### PR DESCRIPTION
Part of #140

## Summary

Remove the remaining operative use of the legacy `Hardware-verified` status
from `.github/skills/update-submodule/SKILL.md`.

The skill now requires build/test evidence using `Compiled` and/or `Tested`.
When hardware/HIL work was performed, it additionally requires the applicable
HIL status defined by
`.github/skills/hil-tdd/references/result-schema.md`.

## Scope

Only this file changes:

- `.github/skills/update-submodule/SKILL.md`

## Verification

- Repository-wide legacy-term scan performed.
- Remaining legacy terms occur only in:
  - the explicit migration warning;
  - the read-only vocabulary-analysis prompt.
- `git diff --check` passes.
- No production code, tests, fixtures, agents, instructions, or other skills changed.
